### PR TITLE
Es werden nur 5 Buttons in der Footerleiste angezeigt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 1.8.7
+- **lux-app-footer**: Es werden nur 5 Buttons in der Footerleiste angezeigt. [Issue 1](https://github.com/IHK-GfI/lux-components/issues/1) 
+
 # Version 1.8.6
 - **allgemein**: Alle Confluence-Verweise auf Github umgestellt. 
 - **allgemein**: README.md erweitert.

--- a/src/app/modules/lux-layout/lux-app-footer/lux-app-footer.component.html
+++ b/src/app/modules/lux-layout/lux-app-footer/lux-app-footer.component.html
@@ -19,8 +19,10 @@
     <lux-menu
       [luxDisplayExtended]="true"
       [luxDisplayMenuLeft]="false"
+      [luxMaximumExtended]="10"
       luxMenuIconName="fa-ellipsis-v"
       luxTagId="app_footer_menu"
+      #buttonMenu
     >
       <ng-container *ngFor="let menuItem of getButtons()">
         <lux-menu-item

--- a/src/app/modules/lux-layout/lux-app-footer/lux-app-footer.component.ts
+++ b/src/app/modules/lux-layout/lux-app-footer/lux-app-footer.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewChild } from '@angular/core';
 import { LuxMediaQueryObserverService } from '../../lux-util/lux-media-query-observer.service';
 import { LuxAppFooterButtonInfo } from './lux-app-footer-button-info';
 import { LuxAppFooterButtonService } from './lux-app-footer-button.service';
 import { LuxAppFooterLinkInfo } from './lux-app-footer-link-info';
 import { LuxAppFooterLinkService } from './lux-app-footer-link.service';
+import { LuxMenuComponent } from '../../lux-action/lux-menu/lux-menu.component';
 
 @Component({
   selector: 'lux-app-footer',
@@ -11,6 +12,8 @@ import { LuxAppFooterLinkService } from './lux-app-footer-link.service';
   styleUrls: ['./lux-app-footer.component.scss']
 })
 export class LuxAppFooterComponent {
+  @ViewChild('buttonMenu', { static: true }) buttonMenu: LuxMenuComponent;
+
   @Input() luxVersion: string;
 
   constructor(


### PR DESCRIPTION
- **lux-app-footer**: Es werden nur 5 Buttons in der Footerleiste angezeigt. [Issue 1](https://github.com/IHK-GfI/lux-components/issues/1)