### PR TITLE
- **lux-error-page**: Der Button wird nur noch angezeigt, wenn eine U…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 1.8.7
 - **lux-app-footer**: Es werden nur 5 Buttons in der Footerleiste angezeigt. [Issue 1](https://github.com/IHK-GfI/lux-components/issues/1) 
+- **lux-error-page**: Der Button wird nur noch angezeigt, wenn eine URL und ein Label hinterlegt sind. [Issue 5](https://github.com/IHK-GfI/lux-components/issues/5)
 
 # Version 1.8.6
 - **allgemein**: Alle Confluence-Verweise auf Github umgestellt. 

--- a/src/app/modules/lux-error/lux-error-page/lux-error-page.component.html
+++ b/src/app/modules/lux-error/lux-error-page/lux-error-page.component.html
@@ -15,6 +15,7 @@
       [luxLabel]="errorConfig.homeRedirectText"
       (luxClicked)="clickHomeRedirect()"
       fxFlex="0 0 auto"
+      *ngIf="errorConfig.homeRedirectText && errorConfig.homeRedirectUrl"
     >
     </lux-button>
     <ng-container *ngIf="error">


### PR DESCRIPTION
…RL und ein Label hinterlegt sind. [Issue 5](https://github.com/IHK-GfI/lux-components/issues/5)