### PR TITLE
Issue 8: Filter-Textfelder (in LUX-Table z.B.) sollten Autocomplete A…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+# Version 1.9.1
+## Features
+- **lux-table**: Die LuxTable stellt jetzt den Filter als LuxInputComponent zur Verfügung. [Issue 8](https://github.com/IHK-GfI/lux-components/issues/8)
+- **lux-table**: Der Defaultwert für das Autocomplete-Attribut des Tabellenfilters ist jetzt "off". [Issue 8](https://github.com/IHK-GfI/lux-components/issues/8)
+- **lux-input**: Das Attribut "luxName" hinzugefügt. [Issue 8](https://github.com/IHK-GfI/lux-components/issues/8)
+- **lux-textarea**: Das Attribut "luxName" hinzugefügt. [Issue 8](https://github.com/IHK-GfI/lux-components/issues/8)
+
 # Version 1.9.0
+## Features
 - **allgemein**: Umstellung auf Angular 9
 
 # Version 1.8.7

--- a/public_api.ts
+++ b/public_api.ts
@@ -173,6 +173,7 @@ export * from './src/app/modules/lux-form/lux-file/lux-file-model/lux-file-objec
 // Directives
 export * from './src/app/modules/lux-form/lux-file/lux-file-model/lux-file-capture.directive';
 export * from './src/app/modules/lux-form/lux-form-control/lux-form-directives/lux-maxlength/lux-max-length.directive';
+export * from './src/app/modules/lux-form/lux-form-control/lux-form-directives/lux-name/lux-name-directive.directive';
 
 /**
  *   _    _   ___  __     _____ ___ _     _____      ____  ____  _______     _____ _______        __

--- a/src/app/demo/baseline/baseline.component.html
+++ b/src/app/demo/baseline/baseline.component.html
@@ -51,7 +51,7 @@
     <lux-checkbox luxControlBinding="checkbox" luxHint="Checkbox" [luxDisabled]="disabled">
       <lux-form-label>Checkbox</lux-form-label>
     </lux-checkbox>
-    <lux-textarea luxControlBinding="textarea" luxLabel="Textarea" luxPlaceholder="Textarea" [luxDisabled]="disabled">
+    <lux-textarea luxName="baseline_Textarea" luxControlBinding="textarea" luxLabel="Textarea" luxPlaceholder="Textarea" [luxDisabled]="disabled">
       <lux-form-hint>Textarea</lux-form-hint>
     </lux-textarea>
     <lux-radio

--- a/src/app/demo/components-overview/accordion-example/accordion-example.component.html
+++ b/src/app/demo/components-overview/accordion-example/accordion-example.component.html
@@ -85,12 +85,12 @@
       </lux-form-hint>
     </lux-radio>
     <div class="example-highlight-config-option" fxLayout="column">
-      <lux-input luxLabel="luxExpandedHeaderHeight" [(luxValue)]="expandedHeaderHeight" class="title-input">
+      <lux-input luxName="accordion_luxExpandedHeaderHeight" luxLabel="luxExpandedHeaderHeight" [(luxValue)]="expandedHeaderHeight" class="title-input">
         <lux-form-hint>
           Diese Property bestimmt die Höhe aller Panel-Header im ausgeklappten Zustand.
         </lux-form-hint>
       </lux-input>
-      <lux-input luxLabel="luxCollapsedHeaderHeight" [(luxValue)]="collapsedHeaderHeight" class="title-input">
+      <lux-input luxName="accordion_luxCollapsedHeaderHeight" luxLabel="luxCollapsedHeaderHeight" [(luxValue)]="collapsedHeaderHeight" class="title-input">
         <lux-form-hint>
           Diese Property bestimmt die Höhe aller Panel-Header im eingeklappten Zustand.
         </lux-form-hint>

--- a/src/app/demo/components-overview/app-footer-example/app-footer-example.component.html
+++ b/src/app/demo/components-overview/app-footer-example/app-footer-example.component.html
@@ -44,6 +44,7 @@
           <lux-panel-content>
             <lux-input
               class="example-highlight-config-option"
+              luxName="app-footer_cmd"
               luxLabel="cmd"
               luxHint="Diese Property ist eine ID, anhand derer der einzelne Button identifiziert werden kann."
               [(luxValue)]="buttonInfo.cmd"
@@ -51,6 +52,7 @@
             </lux-input>
             <lux-input
               class="example-highlight-config-option"
+              luxName="app-footer_label"
               luxLabel="label"
               luxHint="Mit dieser Property wird das Label des Footer-Buttons festgelegt."
               [(luxValue)]="buttonInfo.label"
@@ -58,6 +60,7 @@
             </lux-input>
             <lux-input
               class="example-highlight-config-option"
+              luxName="app-footer_iconName"
               luxLabel="iconName"
               luxHint="Diese Property ermöglicht es, ein Icon für den Footer-Button einzurichten."
               [(luxValue)]="buttonInfo.iconName"
@@ -145,6 +148,7 @@
           <lux-panel-content>
             <lux-input
               class="example-highlight-config-option"
+              luxName="app-footer_label"
               luxLabel="label"
               luxHint="Mit dieser Property wird das Label des Link-Buttons festgelegt."
               [(luxValue)]="linkInfo.label"
@@ -152,6 +156,7 @@
             </lux-input>
             <lux-input
               class="example-highlight-config-option"
+              luxName="app-footer_path"
               luxLabel="path"
               luxHint="Mit dieser Property wird der Pfad des Links bestimmt."
               [(luxValue)]="linkInfo.path"

--- a/src/app/demo/components-overview/autocomplete-example/autocomplete-example.component.html
+++ b/src/app/demo/components-overview/autocomplete-example/autocomplete-example.component.html
@@ -105,6 +105,7 @@
     <lux-divider [luxInset]="true"></lux-divider>
     <lux-input
       class="example-highlight-config-option"
+      luxName="autocomplete_luxLabel"
       luxLabel="luxLabel"
       luxHint="Diese Property ermöglicht es, das Label für die Component zu setzen."
       [(luxValue)]="label"
@@ -112,6 +113,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="autocomplete_luxHint"
       luxLabel="luxHint"
       luxHint="Diese Property ermöglicht es, den Hint für die Component zu setzen."
       [(luxValue)]="hint"
@@ -119,6 +121,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="autocomplete_luxPlaceholder"
       luxLabel="luxPlaceholder"
       luxHint="Diese Property ermöglicht es, den Placeholder für die Component zu setzen."
       [(luxValue)]="placeholder"
@@ -195,6 +198,7 @@
     </lux-toggle>
     <lux-input
       class="example-highlight-config-option"
+      luxName="autocomplete_luxDelay"
       luxLabel="luxDelay"
       luxHint="Über diese Property kann die zeitliche Verzögerung für die Filterung eingestellt werden."
       [(luxValue)]="delay"
@@ -203,6 +207,7 @@
     </lux-input>
     <div fxLayout="column" class="example-highlight-config-option">
       <lux-input
+        luxName="autocomplete_luxErrorMessageNotAnOption"
         luxLabel="luxErrorMessageNotAnOption"
         luxHint="Die Property kann die Fehlermeldung für invalide Optionen einstellen."
         [(luxValue)]="errorMessageNotAnOption"
@@ -220,6 +225,7 @@
       >
       </lux-toggle>
       <lux-input
+        luxName="autocomplete_luxErrorMessage"
         luxLabel="luxErrorMessage"
         luxHint="Über diese Property lässt sich eine feste Fehlermeldung
                  (unabhängig vom speziellen Validierungsfehler) einstellen."

--- a/src/app/demo/components-overview/badge-notification-example/badge-notification-example.component.html
+++ b/src/app/demo/components-overview/badge-notification-example/badge-notification-example.component.html
@@ -35,6 +35,7 @@
     <lux-input
       class="example-highlight-config-option"
       [(luxValue)]="notification"
+      luxName="badge-notification_luxBadgeNotification"
       luxLabel="luxBadgeNotification"
       luxHint="Diese Property definiert den Text-Inhalt der Badge-Notification"
     >
@@ -66,6 +67,7 @@
     <lux-input
       class="example-highlight-config-option"
       [(luxValue)]="cap"
+      luxName="badge-notification_luxBadgeCap"
       luxLabel="luxBadgeCap"
       luxHint="Diese Property legt fest ob eine Maximalzahl nicht überschritten werden darf (Vorausgesetzt das der Inhalt eine Zahl ist)."
     >

--- a/src/app/demo/components-overview/button-example/button-example.component.html
+++ b/src/app/demo/components-overview/button-example/button-example.component.html
@@ -27,10 +27,11 @@
     <lux-input
       class="example-highlight-config-option"
       [(luxValue)]="label"
+      luxName="button_luxLabel"
       luxLabel="luxLabel"
       luxHint="Bestimmt den Text, der in dem Button angezeigt wird."
     ></lux-input>
-    <lux-input class="example-highlight-config-option" [(luxValue)]="iconName" luxLabel="luxIconName">
+    <lux-input luxName="button_luxIconName" class="example-highlight-config-option" [(luxValue)]="iconName" luxLabel="luxIconName">
       <lux-form-hint>
         Diese Property definiert das Icon, welches in dem Button (linksbündig, wenn zusätzlich auch noch
         <i>luxLabel</i> gesetzt ist).<br />

--- a/src/app/demo/components-overview/datepicker-example/datepicker-example.component.html
+++ b/src/app/demo/components-overview/datepicker-example/datepicker-example.component.html
@@ -95,6 +95,7 @@
     <lux-divider [luxInset]="true"></lux-divider>
     <lux-input
       class="example-highlight-config-option"
+      luxName="datepicker_luxLabel"
       luxLabel="luxLabel"
       luxHint="Diese Property ermöglicht es, das Label für die Component zu setzen."
       [(luxValue)]="label"
@@ -102,6 +103,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="datepicker_luxHint"
       luxLabel="luxHint"
       luxHint="Diese Property ermöglicht es, den Hint für die Component zu setzen."
       [(luxValue)]="hint"
@@ -109,6 +111,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="datepicker_luxPlaceholder"
       luxLabel="luxPlaceholder"
       luxHint="Diese Property ermöglicht es, den Placeholder für die Component zu setzen."
       [(luxValue)]="placeholder"
@@ -182,6 +185,7 @@
     </lux-toggle>
     <lux-input
       class="example-highlight-config-option"
+      luxName="datepicker_luxLocale"
       luxLabel="luxLocale"
       luxPlaceholder="de-DE"
       [(luxValue)]="locale"
@@ -200,19 +204,19 @@
     >
     </lux-select>
     <div class="example-highlight-config-option" fxLayout="column">
-      <lux-input luxLabel="luxStartDate" luxPlaceholder="10.02.2015" [(luxValue)]="startDate">
+      <lux-input luxName="datepicker_luxStartDate" luxLabel="luxStartDate" luxPlaceholder="10.02.2015" [(luxValue)]="startDate">
         <lux-form-hint>
           Diese Property definiert das in der Datumsauswahl pre-selektierte Datum.<br />
           Dazu das Datum einfach als String (z.B. 10.02.2015) eingeben.
         </lux-form-hint>
       </lux-input>
-      <lux-input luxLabel="luxMinDate" luxPlaceholder="01.01.2000" [(luxValue)]="minDate">
+      <lux-input luxName="datepicker_luxMinDate" luxLabel="luxMinDate" luxPlaceholder="01.01.2000" [(luxValue)]="minDate">
         <lux-form-hint>
           Diese Property definiert das minimal erlaubte Datum des Datepickers.<br />
           Dazu das Datum einfach als String (z.B. 01.01.2000) eingeben.
         </lux-form-hint>
       </lux-input>
-      <lux-input luxLabel="luxMaxDate" luxPlaceholder="31.12.2099" [(luxValue)]="maxDate">
+      <lux-input luxName="datepicker_luxMaxDate" luxLabel="luxMaxDate" luxPlaceholder="31.12.2099" [(luxValue)]="maxDate">
         <lux-form-hint>
           Diese Property bestimmt maximal erlaubte Datum.<br />
           Dazu das Datum einfach als String (z.B. 31.12.2099) eingeben.
@@ -236,6 +240,7 @@
       >
       </lux-toggle>
       <lux-input
+        luxName="datepicker_luxErrorMessage"
         luxLabel="luxErrorMessage"
         luxHint="Über diese Property lässt sich eine feste Fehlermeldung
                  (unabhängig vom speziellen Validierungsfehler) einstellen."

--- a/src/app/demo/components-overview/dialog-example/dialog-component-example/dialog-component-example.component.html
+++ b/src/app/demo/components-overview/dialog-example/dialog-component-example/dialog-component-example.component.html
@@ -10,7 +10,7 @@
       <span>Ihre Daten werden im Anschluss an diesen Dialog gespeichert.</span>
       <span>{{ luxDialogRef.data }}</span>
       <b>Zusatzinformationen</b>
-      <lux-textarea luxLabel="Anmerkung" luxPlaceholder="Anmerkungen" luxMinRows="1"> </lux-textarea>
+      <lux-textarea luxName="dialog_Anmerkung" luxLabel="Anmerkung" luxPlaceholder="Anmerkungen" luxMinRows="1"> </lux-textarea>
       <lux-toggle
         luxLabel="AGB gelesen"
         luxHint="Ich habe die AGB und Datenschutzvereinbarungen gelesen und akzeptiere diese."

--- a/src/app/demo/components-overview/dialog-example/dialog-example.component.html
+++ b/src/app/demo/components-overview/dialog-example/dialog-example.component.html
@@ -10,6 +10,7 @@
     <h3>Allgemeine Properties</h3>
     <lux-input
       class="example-highlight-config-option"
+      luxName="dialog_width"
       luxLabel="width"
       luxHint="Diese Property legt die Breite des Dialogs fest."
       [(luxValue)]="dialogConfig.width"
@@ -17,6 +18,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="dialog_height"
       luxLabel="height"
       luxHint="Diese Property legt die Höhe des Dialogs fest."
       [(luxValue)]="dialogConfig.height"
@@ -24,6 +26,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="dialog_panelClass"
       luxLabel="panelClass"
       [luxValue]="dialogConfig.panelClass"
       (luxBlur)="updatePanelClass(panelClassInput.luxValue)"
@@ -48,6 +51,7 @@
     <h3>Properties für Preset-Dialoge</h3>
     <lux-input
       class="example-highlight-config-option"
+      luxName="dialog_title"
       luxLabel="title"
       luxHint="Diese Property enthält den Titel des Dialogs."
       [(luxValue)]="dialogConfig.title"
@@ -63,6 +67,7 @@
       </lux-toggle>
       <pre class="lux-label" *ngIf="useContentTemplate">{{ contentTemplateString }}</pre>
       <lux-input
+        luxName="dialog_content"
         luxLabel="content"
         luxHint="Über diese Eigenschaft der eigentliche Inhalt des Dialogs bestimmt."
         [(luxValue)]="dialogConfig.content"
@@ -91,7 +96,7 @@
       </lux-panel>
     </lux-accordion>
     <h3>Beispiel für "data" für eigene Dialoge</h3>
-    <lux-input class="example-highlight-config-option" luxLabel="data" [(luxValue)]="exampleData">
+    <lux-input luxName="dialog_data" class="example-highlight-config-option" luxLabel="data" [(luxValue)]="exampleData">
       <lux-form-hint>
         Dieses Objekt wird einem eigenen Dialog während 'openComponent' mitgegeben und enthält Daten, die für die
         Dialog-Componente wichtig sein könnten.
@@ -124,9 +129,10 @@
 </ng-template>
 
 <ng-template let-actionConfig #dialogActionTemplate>
-  <lux-input luxLabel="label" luxHint="Diese Property enthält das Label der Aktion." [(luxValue)]="actionConfig.label">
+  <lux-input luxName="dialog_label" luxLabel="label" luxHint="Diese Property enthält das Label der Aktion." [(luxValue)]="actionConfig.label">
   </lux-input>
   <lux-input
+    luxName="dialog_iconName"
     luxLabel="iconName"
     luxHint="Diese Property bestimmt das Icon der Aktion"
     [(luxValue)]="actionConfig.iconName"

--- a/src/app/demo/components-overview/errorpage-example/errorpage-example.component.html
+++ b/src/app/demo/components-overview/errorpage-example/errorpage-example.component.html
@@ -8,6 +8,7 @@
       <h3>Error Properties</h3>
       <lux-input
         class="example-highlight-config-option"
+        luxName="error-page_errorId"
         luxLabel="errorId"
         luxHint="Diese Property enthält die Fehler-ID."
         [(luxValue)]="errorConfig.errorId"
@@ -15,6 +16,7 @@
       </lux-input>
       <lux-input
         class="example-highlight-config-option"
+        luxName="error-page_errorMessage"
         luxLabel="errorMessage"
         luxHint="Die Property definiert die Fehlermeldung selbst, welche in dem Panel auf der Fehlerseite dargestellt wird."
         [(luxValue)]="errorConfig.errorMessage"
@@ -25,6 +27,7 @@
       <h3>Error-Page Properties</h3>
       <lux-input
         class="example-highlight-config-option"
+        luxName="error-page_iconName"
         luxLabel="iconName"
         luxHint="Diese Property definiert das Icon, das auf der Fehlerseite dargestellt wird."
         luxControlBinding="iconName"
@@ -40,6 +43,7 @@
       </lux-select>
       <lux-input
         class="example-highlight-config-option"
+        luxName="error-page_errorText"
         luxLabel="errorText"
         luxHint="Diese Property definiert den Fehlertext auf der Seite."
         luxControlBinding="errorText"
@@ -47,6 +51,7 @@
       </lux-input>
       <lux-input
         class="example-highlight-config-option"
+        luxName="error-page_homeRedirectText"
         luxLabel="homeRedirectText"
         luxHint="Über diese Property kann der Text für den Home-Link bestimmt werden."
         luxControlBinding="homeRedirectText"
@@ -54,12 +59,13 @@
       </lux-input>
       <lux-input
         class="example-highlight-config-option"
+        luxName="error-page_homeRedirectUrl"
         luxLabel="homeRedirectUrl"
         luxHint="Die Property bestimmt die URL, zu der über den entsprechenden Link gesprungen werden kann."
         luxControlBinding="homeRedirectUrl"
       >
       </lux-input>
-      <lux-input class="example-highlight-config-option" luxLabel="errorPageUrl" luxControlBinding="errorPageUrl">
+      <lux-input luxName="error-page_errorPageUrl" class="example-highlight-config-option" luxLabel="errorPageUrl" luxControlBinding="errorPageUrl">
         <lux-form-hint>
           Diese Property definiert die eigentliche URL der Fehlerseite innerhalb der Angular-Applikation. Die URL muss
           in den bekannten Routen hinterlegt sein (das Beispiel macht das in diesem Fall selbst).<br />

--- a/src/app/demo/components-overview/infinite-scrolling-example/infinite-scrolling-example.component.html
+++ b/src/app/demo/components-overview/infinite-scrolling-example/infinite-scrolling-example.component.html
@@ -52,6 +52,7 @@
     <lux-input
       class="example-highlight-config-option"
       luxType="number"
+      luxName="infinite-scrolling_luxScrollPercent"
       luxLabel="luxScrollPercent"
       luxHint="Bestimmt die Prozentzahl in der Scrollbar, ab der das luxScrolled-Event emitted wird."
       [(luxValue)]="scrollPercent"

--- a/src/app/demo/components-overview/link-example/link-example.component.html
+++ b/src/app/demo/components-overview/link-example/link-example.component.html
@@ -26,7 +26,7 @@
       [(luxChecked)]="showOutputEvents"
     ></lux-toggle>
     <lux-divider [luxInset]="true"></lux-divider>
-    <lux-input class="example-highlight-config-option" [(luxValue)]="href" luxLabel="luxHref">
+    <lux-input luxName="link_luxHref" class="example-highlight-config-option" [(luxValue)]="href" luxLabel="luxHref">
       <lux-form-hint>
         Bestimmt die URL, zu der der Link routet.<br />
         Wenn die URL nicht mit <i>http</i> beginnt, wird automatisch der Angular-Router für Routing innerhalb der

--- a/src/app/demo/components-overview/list-example/list-example.component.html
+++ b/src/app/demo/components-overview/list-example/list-example.component.html
@@ -46,6 +46,7 @@
     <lux-input
       class="example-highlight-config-option"
       [(luxValue)]="emptyLabel"
+      luxName="list_luxEmptyLabel"
       luxLabel="luxEmptyLabel"
       luxHint="Diese Property stellt das Label ein, welches bei einer leeren Liste angezeigt werden soll."
     >
@@ -53,6 +54,7 @@
     <div class="example-highlight-config-option" fxLayout="column">
       <lux-input
         [(luxValue)]="emptyIconName"
+        luxName="list_luxEmptyIconName"
         luxLabel="luxEmptyIconName"
         luxHint="Über diese Property wird das Icon bestimmt, das in einer leeren Liste angezeigt werden soll."
       >
@@ -68,6 +70,7 @@
     <lux-input
       class="example-highlight-config-option"
       [(luxValue)]="selectedPosition"
+      luxName="list_luxSelectedPosition"
       luxLabel="luxSelectedPosition"
       luxHint="Diese Property bestimmt welches ListItem selektiert werden soll."
       luxType="number"
@@ -76,6 +79,7 @@
     <lux-input
       class="example-highlight-config-option"
       [(luxValue)]="focusedPosition"
+      luxName="list_luxFocusedPosition"
       luxLabel="luxFocusedPosition"
       luxHint="Diese Property bestimmt welches ListItem fokussiert werden soll."
       luxType="number"
@@ -92,18 +96,20 @@
           <div class="example-highlight-config-option" fxLayout="column">
             <lux-input
               [(luxValue)]="item.title"
+              luxName="list_luxTitle"
               luxLabel="luxTitle"
               luxHint="Diese Property bestimmt den Titel des Items."
             >
             </lux-input>
             <lux-input
               [(luxValue)]="item.subTitle"
+              luxName="list_luxSubTitle"
               luxLabel="luxSubTitle"
               luxHint="Diese Property bestimmt den Untertitel (grau) des Items."
             >
             </lux-input>
           </div>
-          <lux-input class="example-highlight-config-option" [(luxValue)]="item.iconName" luxLabel="luxIconName">
+          <lux-input luxName="list_luxIconName" class="example-highlight-config-option" [(luxValue)]="item.iconName" luxLabel="luxIconName">
             <lux-form-hint>
               Der Name des Icons für dieses Item.<br />
               Das Icon wird über Content-Projection eingebunden, die restlichen Properties hierfür entfallen der

--- a/src/app/demo/components-overview/lookup-examples/lookup-autocomplete-example/lookup-autocomplete-example.component.html
+++ b/src/app/demo/components-overview/lookup-examples/lookup-autocomplete-example/lookup-autocomplete-example.component.html
@@ -117,6 +117,7 @@
           <div fxLayout="column">
             <lux-input
               class="example-highlight-config-option"
+              luxName="lookup_autocomplete_luxTableNo"
               luxLabel="luxTableNo"
               [(luxValue)]="tableNo"
               luxType="number"
@@ -125,6 +126,7 @@
             <div class="example-highlight-config-option" fxLayout="column">
               <h3>Parameter</h3>
               <lux-input
+                luxName="lookup_autocomplete_knr"
                 luxLabel="Knr"
                 [(luxValue)]="parameters.knr"
                 luxType="number"
@@ -156,6 +158,7 @@
     </div>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup_autocomplete_luxLabel"
       luxLabel="luxLabel"
       luxHint="Diese Property ermöglicht es, das Label für die Component zu setzen."
       [(luxValue)]="label"
@@ -163,6 +166,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup_autocomplete_luxHint"
       luxLabel="luxHint"
       luxHint="Diese Property ermöglicht es, den Hint für die Component zu setzen."
       [(luxValue)]="hint"
@@ -170,6 +174,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup_autocomplete_luxPlaceholder"
       luxLabel="luxPlaceholder"
       luxHint="Diese Property ermöglicht es, den Placeholder für die Component zu setzen."
       [(luxValue)]="placeholder"
@@ -222,6 +227,7 @@
   <example-base-advanced-options>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup_autocomplete_luxDebounceTime"
       luxLabel="luxDebounceTime"
       luxHint="Diese Property setzt die zeitliche Verzögerung, bevor die Daten nach einem neuen Suchbegriff gefiltert werden."
       [(luxValue)]="debounceTime"
@@ -229,6 +235,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup_autocomplete_luxMaximumDisplay"
       luxLabel="luxMaximumDisplayed"
       luxHint="Hier kann eingestellt werden, wie viele Suchergebnisse im ausgeklappten Menu dargestellt werden."
       [(luxValue)]="maximumDisplayed"
@@ -244,6 +251,7 @@
       <pre class="lux-label" *ngIf="useRenderFn"><b>renderFn</b> = {{ renderFnString }}</pre>
       <lux-input
         [(luxValue)]="renderProp"
+        luxName="lookup_autocomplete_luxRenderProp"
         luxLabel="luxRenderProp"
         luxHint="Hier kann die Property festgelegt werden, welche zur Darstellung der einzelnen Einträge genutzt wird."
         *ngIf="!useRenderFn"
@@ -293,6 +301,7 @@
       </lux-toggle>
       <pre class="lux-label" *ngIf="!useErrorMessage"><b>luxErrorCallback</b> = {{ errorCallbackString }}</pre>
       <lux-input
+        luxName="lookup_autocomplete_luxErrorMessage"
         luxLabel="luxErrorMessage"
         luxHint="Über diese Property lässt sich eine feste Fehlermeldung
                  (unabhängig vom speziellen Validierungsfehler) einstellen."

--- a/src/app/demo/components-overview/lookup-examples/lookup-combobox-example/lookup-combobox-example.component.html
+++ b/src/app/demo/components-overview/lookup-examples/lookup-combobox-example/lookup-combobox-example.component.html
@@ -154,6 +154,7 @@
           <div fxLayout="column">
             <lux-input
               class="example-highlight-config-option"
+              luxName="lookup-combobox_luxTableNo"
               luxLabel="luxTableNo"
               [(luxValue)]="tableNo"
               luxType="number"
@@ -162,6 +163,7 @@
             <div class="example-highlight-config-option" fxLayout="column">
               <h3>Parameter</h3>
               <lux-input
+                luxName="lookup-combobox_knr"
                 luxLabel="Knr"
                 [(luxValue)]="parameters.knr"
                 luxType="number"
@@ -193,6 +195,7 @@
     </div>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup-combobox_luxLabel"
       luxLabel="luxLabel"
       luxHint="Diese Property ermöglicht es, das Label für die Component zu setzen."
       [(luxValue)]="label"
@@ -200,6 +203,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup-combobox_luxHint"
       luxLabel="luxHint"
       luxHint="Diese Property ermöglicht es, den Hint für die Component zu setzen."
       [(luxValue)]="hint"
@@ -207,6 +211,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup-combobox_luxPlaceholder"
       luxLabel="luxPlaceholder"
       luxHint="Diese Property ermöglicht es, den Placeholder für die Component zu setzen."
       [(luxValue)]="placeholder"
@@ -259,6 +264,7 @@
   <example-base-advanced-options>
     <lux-input
       class="example-highlight-config-option"
+      luxName="lookup-combobox_luxEntryBlockSize"
       luxLabel="luxEntryBlockSize"
       [(luxValue)]="entryBlockSize"
       luxType="number"
@@ -278,6 +284,7 @@
       <pre class="lux-label" *ngIf="useRenderFn"><b>renderFn</b> = {{ renderFnString }}</pre>
       <lux-input
         [(luxValue)]="renderProp"
+        luxName="lookup-combobox_luxRenderProp"
         luxLabel="luxRenderProp"
         luxHint="Hier kann die Property festgelegt werden, welche zur Darstellung der einzelnen Einträge genutzt wird."
         *ngIf="!useRenderFn"
@@ -335,6 +342,7 @@
       </lux-toggle>
       <pre class="lux-label" *ngIf="!useErrorMessage"><b>luxErrorCallback</b> = {{ errorCallbackString }}</pre>
       <lux-input
+        luxName="lookup-combobox_luxErrorMessage"
         luxLabel="luxErrorMessage"
         luxHint="Über diese Property lässt sich eine feste Fehlermeldung
                  (unabhängig vom speziellen Validierungsfehler) einstellen."

--- a/src/app/demo/components-overview/lookup-examples/lookup-label-example/lookup-label-example.component.html
+++ b/src/app/demo/components-overview/lookup-examples/lookup-label-example/lookup-label-example.component.html
@@ -22,8 +22,8 @@
     </lux-toggle>
     <lux-divider [luxInset]="true"></lux-divider>
     <div fxLayout="column">
-      <lux-input luxLabel="Knr" [(luxValue)]="knr" luxType="number" [luxNumberAlignLeft]="true"></lux-input>
-      <lux-input class="example-highlight-config-option" luxLabel="luxTableNo" [(luxValue)]="tableNo" luxType="number">
+      <lux-input luxName="lookup-label_knr" luxLabel="Knr" [(luxValue)]="knr" luxType="number" [luxNumberAlignLeft]="true"></lux-input>
+      <lux-input luxName="lookup-label_luxTableNo" class="example-highlight-config-option" luxLabel="luxTableNo" [(luxValue)]="tableNo" luxType="number">
         <lux-form-hint>
           Die Property bestimmt die Schlüsseltabelle aus der die Daten geladen werden sollen.<br />
           Wenn Mock-Resultate aufgerufen werden, hat die Property keine Auswirkung.
@@ -31,6 +31,7 @@
       </lux-input>
       <lux-input
         class="example-highlight-config-option"
+        luxName="lookup-label_luxTableKey"
         luxLabel="luxTableKey"
         (luxBlur)="start()"
         [(luxValue)]="tableKey"

--- a/src/app/demo/components-overview/master-detail-example/detail-example/detail-example.component.html
+++ b/src/app/demo/components-overview/master-detail-example/detail-example/detail-example.component.html
@@ -6,6 +6,7 @@
     <div fxLayout="column" fxLayoutGap="4px">
       <div fxLayout.gt-sm="row" fxLayoutGap.gt-sm="8px" fxLayout="column" fxLayoutGap="0">
         <lux-input
+          luxName="master-detail_luxEmptyLabelDetail"
           luxLabel="luxEmptyLabelDetail"
           luxHint="Diese Property bestimmt das Label welches angezeigt wird, wenn kein Detail selektiert ist."
           [(luxValue)]="masterDetailConfig.emptyLabelDetail"
@@ -13,6 +14,7 @@
         >
         </lux-input>
         <lux-input
+          luxName="master-detail_luxEmptyLabelMaster"
           luxLabel="luxEmptyLabelMaster"
           luxHint="Diese Property bestimmt das Label welches angezeigt wird, wenn keine Master-Elemente vorhanden sind."
           [(luxValue)]="masterDetailConfig.emptyLabelMaster"
@@ -22,6 +24,7 @@
       </div>
       <div fxLayout.gt-sm="row" fxLayoutGap.gt-sm="8px" fxLayout="column" fxLayoutGap="0">
         <lux-input
+          luxName="master-detail_luxEmptyIconDetail"
           luxLabel="luxEmptyIconDetail"
           luxHint="Die Property legt das Icon fest, das angezeigt wird wenn kein Detail ausgewählt ist."
           [(luxValue)]="masterDetailConfig.emptyIconDetail"
@@ -29,6 +32,7 @@
         >
         </lux-input>
         <lux-input
+          luxName="master-detail_luxEmptyIconMaster"
           luxLabel="luxEmptyIconMaster"
           luxHint="Die Property legt das Icon fest, das angezeigt wird wenn keine Master-Elemente vorhanden sind."
           [(luxValue)]="masterDetailConfig.emptyIconMaster"

--- a/src/app/demo/components-overview/message-box-example/message-box-example.component.html
+++ b/src/app/demo/components-overview/message-box-example/message-box-example.component.html
@@ -20,6 +20,7 @@
     <lux-divider [luxInset]="true"></lux-divider>
     <lux-input
       class="example-highlight-config-option"
+      luxName="message-box_luxIndex"
       luxLabel="luxIndex"
       luxHint="Diese Property bestimmt die aktuell angezeigte Page aus dem Paginator (maximal die letzte mögliche Seite)."
       luxType="number"
@@ -28,6 +29,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="message-box_luxMaximumDisplayed"
       luxLabel="luxMaximumDisplayed"
       luxType="number"
       [(luxValue)]="maximumDisplayed"
@@ -43,6 +45,7 @@
       <h3>Neue Message</h3>
       <div class="example-highlight-config-option" fxLayout="column">
         <lux-textarea
+          luxName="message-box_text"
           luxLabel="text"
           luxHint="Die Property bestimmt den Text für die neue Nachricht."
           [(luxValue)]="newMessage.text"
@@ -50,6 +53,7 @@
         >
         </lux-textarea>
         <lux-input
+          luxName="message-box_iconName"
           luxLabel="iconName"
           luxHint="Über diese Property wird optional ein Icon festgelegt."
           [(luxValue)]="newMessage.iconName"
@@ -100,6 +104,7 @@
           <div fxLayout="column">
             <lux-textarea
               class="example-highlight-config-option"
+              luxName="message-box_text"
               luxLabel="text"
               luxHint="Die Property bestimmt den Text für die Nachricht."
               [(luxValue)]="message.text"
@@ -108,6 +113,7 @@
             </lux-textarea>
             <lux-input
               class="example-highlight-config-option"
+              luxName="message-box_iconName"
               luxLabel="iconName"
               luxHint="Über diese Property wird optional ein Icon festgelegt."
               [(luxValue)]="message.iconName"

--- a/src/app/demo/components-overview/radio-button-example/radio-button-example.component.html
+++ b/src/app/demo/components-overview/radio-button-example/radio-button-example.component.html
@@ -84,6 +84,7 @@
     <lux-divider [luxInset]="true"></lux-divider>
     <lux-input
       class="example-highlight-config-option"
+      luxName="radio_luxLabel"
       luxLabel="luxLabel"
       luxHint="Diese Property ermöglicht es, das Label für die Component zu setzen."
       [(luxValue)]="label"
@@ -91,6 +92,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="radio_luxHint"
       luxLabel="luxHint"
       luxHint="Diese Property ermöglicht es, den Hint für die Component zu setzen."
       [(luxValue)]="hint"
@@ -195,13 +197,13 @@
       </lux-form-hint>
     </lux-toggle>
     <div class="example-highlight-config-option" fxLayout="column">
-      <lux-input luxLabel="luxGroupName - normales Beispiel" [(luxValue)]="groupNameNormal" fxFlex="auto">
+      <lux-input luxName="radio_luxGroupName" luxLabel="luxGroupName - normales Beispiel" [(luxValue)]="groupNameNormal" fxFlex="auto">
         <lux-form-hint>
           Diese Property definiert die Radio-Group, zu der die einzelnen Radio-Buttons gehören sollen.<br />
           Wenn derselbe Name für 2 Radio-Components genutzt wird, agieren diese wie eine gemeinsame Group.
         </lux-form-hint>
       </lux-input>
-      <lux-input luxLabel="luxGroupName - ReactiveForm Beispiel" [(luxValue)]="groupNameReactive" fxFlex="auto">
+      <lux-input luxName="radio_luxGroupName" luxLabel="luxGroupName - ReactiveForm Beispiel" [(luxValue)]="groupNameReactive" fxFlex="auto">
         <lux-form-hint>
           Diese Property definiert die Radio-Group, zu der die einzelnen Radio-Buttons gehören sollen.<br />
           Wenn derselbe Name für 2 Radio-Components genutzt wird, agieren diese wie eine gemeinsame Group.
@@ -216,6 +218,7 @@
       >
       </lux-toggle>
       <lux-input
+        luxName="radio_luxErrorMessage"
         luxLabel="luxErrorMessage"
         luxHint="Über diese Property lässt sich eine feste Fehlermeldung
                  (unabhängig vom speziellen Validierungsfehler) einstellen."

--- a/src/app/demo/components-overview/ripple-example/ripple-example.component.html
+++ b/src/app/demo/components-overview/ripple-example/ripple-example.component.html
@@ -23,6 +23,7 @@
   <example-base-simple-options>
     <lux-input
       class="example-highlight-config-option"
+      luxName="ripple_luxRippleColor"
       luxLabel="luxRippleColor"
       luxHint="Diese Property ermöglicht es, die Farbe der Component zu setzen."
       [(luxValue)]="color"
@@ -30,6 +31,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="ripple_luxRippleRadius"
       luxLabel="luxRippleRadius"
       luxHint="Diese Property ermöglicht es, den Radius der Animation festzulegen. Wenn 0 werden die Begrenzungen der Zielcomponent genommen."
       luxType="number"
@@ -38,6 +40,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="ripple_luxRippleEnterDuration"
       luxLabel="luxRippleEnterDuration"
       luxHint="Diese Property ermöglicht es, die Dauer der Eingangsanimation zu bestimmen."
       luxType="number"
@@ -46,6 +49,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="ripple_luxRippleExitDuration"
       luxLabel="luxRippleExitDuration"
       luxHint="Diese Property ermöglicht es, die Dauer der Ausgangsanimation zu bestimmen."
       luxType="number"

--- a/src/app/demo/components-overview/select-example/select-example.component.html
+++ b/src/app/demo/components-overview/select-example/select-example.component.html
@@ -113,6 +113,7 @@
     <lux-divider [luxInset]="true"></lux-divider>
     <lux-input
       class="example-highlight-config-option"
+      luxName="select_luxLabel"
       luxLabel="luxLabel"
       luxHint="Diese Property ermöglicht es, das Label für die Component zu setzen."
       [(luxValue)]="label"
@@ -120,6 +121,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="select_luxHint"
       luxLabel="luxHint"
       luxHint="Diese Property ermöglicht es, den Hint für die Component zu setzen."
       [(luxValue)]="hint"
@@ -127,6 +129,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="select_luxPlaceholder"
       luxLabel="luxPlaceholder"
       luxHint="Diese Property ermöglicht es, den Placeholder für die Component zu setzen."
       [(luxValue)]="placeholder"
@@ -231,6 +234,7 @@
       >
       </lux-toggle>
       <lux-input
+        luxName="select_luxErrorMessage"
         luxLabel="luxErrorMessage"
         luxHint="Über diese Property lässt sich eine feste Fehlermeldung
                  (unabhängig vom speziellen Validierungsfehler) einstellen."

--- a/src/app/demo/components-overview/slider-example/slider-example.component.html
+++ b/src/app/demo/components-overview/slider-example/slider-example.component.html
@@ -104,6 +104,7 @@
     <lux-divider [luxInset]="true"></lux-divider>
     <lux-input
       class="example-highlight-config-option"
+      luxName="slider_luxLabel"
       luxLabel="luxLabel"
       luxHint="Diese Property ermöglicht es, das Label für die Component zu setzen."
       [(luxValue)]="label"
@@ -111,6 +112,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="slider_luxHint"
       luxLabel="luxHint"
       luxHint="Diese Property ermöglicht es, den Hint für die Component zu setzen."
       [(luxValue)]="hint"
@@ -173,12 +175,14 @@
       <lux-input
         [(luxValue)]="min"
         luxType="number"
+        luxName="slider_luxMin"
         luxLabel="luxMin"
         luxHint="Diese Property bestimmt den minimal möglichen Wert in dem Slider."
       ></lux-input>
       <lux-input
         [(luxValue)]="max"
         luxType="number"
+        luxName="slider_luxMax"
         luxLabel="luxMax"
         luxHint="Diese Property bestimmt den maximal möglichen Wert des Sliders."
       >
@@ -186,6 +190,7 @@
       <lux-input
         luxType="number"
         [(luxValue)]="step"
+        luxName="slider_luxStep"
         luxLabel="luxStep"
         luxHint="Über die Property wird die Schrittgröße, in denen der Slider die Werte ändert bestimmt."
       >
@@ -203,6 +208,7 @@
       <lux-input
         luxType="number"
         [luxValue]="tickIntervalNumber"
+        luxName="slider_luxTickInterval"
         luxLabel="luxTickInterval - 'number'"
         luxHint="Die Property kann ebenfalls einen Zahlenwert erhalten, um so die Abstände festzulegen."
         (luxValueChange)="tickIntervalNumberChanged($event)"
@@ -242,6 +248,7 @@
       >
       </lux-toggle>
       <lux-input
+        luxName="slider_luxErrorMessage"
         luxLabel="luxErrorMessage"
         luxHint="Über diese Property lässt sich eine feste Fehlermeldung
                  (unabhängig vom speziellen Validierungsfehler) einstellen."

--- a/src/app/demo/components-overview/tabindex-example/tabindex-example.component.html
+++ b/src/app/demo/components-overview/tabindex-example/tabindex-example.component.html
@@ -20,7 +20,7 @@
             </ng-template>
           </lux-chip-group>
         </lux-chips>
-        <lux-textarea luxLabel="Tabindex 7 (LuxTextarea)" luxTabIndex="7"></lux-textarea>
+        <lux-textarea luxName="tabindex_Tabindex7" luxLabel="Tabindex 7 (LuxTextarea)" luxTabIndex="7"></lux-textarea>
         <lux-radio
           luxLabel="Tabindex 9 (LuxRadio)"
           [luxOptions]="options"

--- a/src/app/demo/components-overview/tabs-example/tabs-example.component.html
+++ b/src/app/demo/components-overview/tabs-example/tabs-example.component.html
@@ -25,9 +25,9 @@
       >
         <ng-template>
           <div fxLayout="column">
-            <lux-input luxLabel="Beispiel Eingabefeld #{{ 1 + i * 3 }}" luxTagId="BE_{{ 1 + i * 3 }}"></lux-input>
-            <lux-input luxLabel="Beispiel Eingabefeld #{{ 2 + i * 3 }}" luxTagId="BE_{{ 1 + i * 3 }}"></lux-input>
-            <lux-textarea luxLabel="Beispiel Eingabefeld #{{ 3 + i * 3 }}" luxTagId="BE_{{ 1 + i * 3 }}"></lux-textarea>
+            <lux-input luxLabel="Beispiel Eingabefeld #{{ 1 + i * 3 }}" luxTagId="BE_{{ 1 + i * 3 }}" luxAutocomplete="off"></lux-input>
+            <lux-input luxLabel="Beispiel Eingabefeld #{{ 2 + i * 3 }}" luxTagId="BE_{{ 1 + i * 3 }}" luxAutocomplete="off"></lux-input>
+            <lux-textarea luxLabel="Beispiel Eingabefeld #{{ 3 + i * 3 }}" luxTagId="BE_{{ 1 + i * 3 }}" luxAutocomplete="off"></lux-textarea>
             <app-tabs-content (created)="tabContentCreated(tab)"></app-tabs-content>
           </div>
         </ng-template>

--- a/src/app/demo/components-overview/textarea-example/textarea-example.component.html
+++ b/src/app/demo/components-overview/textarea-example/textarea-example.component.html
@@ -7,6 +7,7 @@
     <div fxLayout="column">
       <h3>Beispiel ohne Reactive-Form</h3>
       <lux-textarea
+        luxName="textarea_withoutForm"
         [(luxDisabled)]="disabled"
         [luxRequired]="required"
         [luxReadonly]="readonly"
@@ -35,6 +36,7 @@
     <div fxLayout="column" [formGroup]="form">
       <h3>Beispiel in Reactive-Form</h3>
       <lux-textarea
+        luxName="textarea_withForm"
         [(luxDisabled)]="disabled"
         [luxReadonly]="readonly"
         [luxAutocomplete]="autocomplete"

--- a/src/app/demo/components-overview/timestamp-example/timestamp-example.component.html
+++ b/src/app/demo/components-overview/timestamp-example/timestamp-example.component.html
@@ -61,12 +61,13 @@
     <lux-input
       class="example-highlight-config-option"
       luxAutocomplete="off"
+      luxName="timestamp_defaultText"
       luxLabel="defaultText"
       luxHint="Dieser Parameter bestimmt den Standard-Text welcher wiedergegeben wird wenn der Timestamp nicht gegeben ist."
       [(luxValue)]="defaultText"
     >
     </lux-input>
-    <lux-input class="example-highlight-config-option" luxAutocomplete="off" luxLabel="prefix" [(luxValue)]="prefix">
+    <lux-input luxName="timestamp_prefix" class="example-highlight-config-option" luxAutocomplete="off" luxLabel="prefix" [(luxValue)]="prefix">
       <lux-form-hint>
         Dieser Parameter legt den Präfix für die relativen Zeitangaben fest.<br />
         Standardmäßig werden die Präfixe 'in' und 'vor' benutzt.

--- a/src/app/demo/components-overview/toggle-example/toggle-example.component.html
+++ b/src/app/demo/components-overview/toggle-example/toggle-example.component.html
@@ -59,6 +59,7 @@
   <example-base-simple-options>
     <lux-input
       class="example-highlight-config-option"
+      luxName="toggle_luxLabel"
       luxLabel="luxLabel"
       luxHint="Diese Property ermöglicht es, das Label für die Component zu setzen."
       [(luxValue)]="label"
@@ -66,6 +67,7 @@
     </lux-input>
     <lux-input
       class="example-highlight-config-option"
+      luxName="toggle_luxHint"
       luxLabel="luxHint"
       luxHint="Diese Property ermöglicht es, den Hint für die Component zu setzen."
       [(luxValue)]="hint"

--- a/src/app/demo/form/form-common/form-common.component.html
+++ b/src/app/demo/form/form-common/form-common.component.html
@@ -3,14 +3,14 @@
     <form [formGroup]="myGroup" #myForm>
       <div formGroupName="user">
         <h3>Benutzer</h3>
-        <lux-input luxLabel="Vorname" luxControlBinding="firstname"></lux-input>
-        <lux-input luxLabel="Nachname" luxControlBinding="lastname"></lux-input>
-        <lux-input luxLabel="E-Mail" luxControlBinding="email">
+        <lux-input luxName="first-name" luxLabel="Vorname" luxControlBinding="firstname"></lux-input>
+        <lux-input luxName="given-name" luxLabel="Nachname" luxControlBinding="lastname"></lux-input>
+        <lux-input luxName="email" luxLabel="E-Mail" luxControlBinding="email">
           <lux-input-suffix>
             <lux-icon luxIconName="fa-at"></lux-icon>
           </lux-input-suffix>
         </lux-input>
-        <lux-input luxLabel="Passwort" luxControlBinding="password" luxType="password">
+        <lux-input luxName="current-password" luxLabel="Passwort" luxControlBinding="password" luxType="password">
           <lux-input-suffix>
             <lux-icon luxIconName="fa-lock"></lux-icon>
           </lux-input-suffix>
@@ -25,7 +25,7 @@
         [luxMultiple]="true"
       ></lux-select>
       <lux-toggle luxLabel="Newsletter" luxControlBinding="newsletter"></lux-toggle>
-      <lux-input luxLabel="Spende" luxControlBinding="donation" luxType="number">
+      <lux-input luxName="form-common_Spende" luxLabel="Spende" luxControlBinding="donation" luxType="number">
         <lux-input-prefix>
           <lux-icon luxIconName="fa-money"></lux-icon>
         </lux-input-prefix>
@@ -33,7 +33,7 @@
           €
         </lux-input-suffix>
       </lux-input>
-      <lux-input luxLabel="Beschreibung" luxControlBinding="description"></lux-input>
+      <lux-input luxName="form-common_Beschreibung" luxLabel="Beschreibung" luxControlBinding="description"></lux-input>
       <lux-checkbox luxControlBinding="hungry" luxLabel="Hungrig"></lux-checkbox>
 
       <lux-chips

--- a/src/app/demo/form/form-dual-col/form-dual-col.component.html
+++ b/src/app/demo/form/form-dual-col/form-dual-col.component.html
@@ -4,10 +4,22 @@
       <div fxLayout="column" fxLayout.gt-md="row" class="lux-flex-layout-gap-10">
         <div formGroupName="customerDetails" fxLayout="column" fxFlex="1 1 50%">
           <h2>Kundeninformationen</h2>
-          <lux-input luxLabel="Name" luxControlBinding="name" fxFlex="auto"></lux-input>
+          <lux-input luxName="name" luxLabel="Name" luxControlBinding="name" fxFlex="auto"></lux-input>
           <div fxLayout="row" fxLayoutAlign="start stretch" class="lux-flex-layout-gap-10">
-            <lux-input luxLabel="PLZ" luxType="number" luxControlBinding="zip" fxFlex="25"></lux-input>
-            <lux-input luxLabel="Stadt" luxType="text" luxControlBinding="town" fxFlex="75"></lux-input>
+            <lux-input
+              luxName="postal-code"
+              luxLabel="PLZ"
+              luxType="number"
+              luxControlBinding="zip"
+              fxFlex="25"
+            ></lux-input>
+            <lux-input
+              luxName="form-dual-Stadt"
+              luxLabel="Stadt"
+              luxType="text"
+              luxControlBinding="town"
+              fxFlex="75"
+            ></lux-input>
           </div>
           <lux-autocomplete
             [luxOptions]="countries"
@@ -23,8 +35,20 @@
           <div formArrayName="streets" fxLayout="column">
             <div *ngFor="let street of streetsFormArray.controls; let i = index" [formGroupName]="i">
               <div fxLayout="row" fxLayoutAlign="start stretch" class="lux-flex-layout-gap-10">
-                <lux-input luxLabel="Straße" luxType="text" luxControlBinding="streetName" fxFlex="auto"></lux-input>
-                <lux-input luxLabel="Nr" luxType="number" luxControlBinding="nr" fxFlex="0 0 15"></lux-input>
+                <lux-input
+                  luxName="street-address"
+                  luxLabel="Straße"
+                  luxType="text"
+                  luxControlBinding="streetName"
+                  fxFlex="auto"
+                ></lux-input>
+                <lux-input
+                  luxName="form-dual-Nr"
+                  luxLabel="Nr"
+                  luxType="number"
+                  luxControlBinding="nr"
+                  fxFlex="0 0 15"
+                ></lux-input>
                 <lux-button
                   luxIconName="fas fa-trash"
                   (luxClicked)="removeStreet(i)"
@@ -53,11 +77,28 @@
         </div>
         <div formGroupName="orderDetails" fxLayout="column" fxFlex="1 1 50%">
           <h2>Bestellinformationen</h2>
-          <lux-input luxLabel="Bestellnr." luxControlBinding="orderNo" fxFlex="nogrow"></lux-input>
-          <lux-input luxLabel="Bestellwert" luxType="text" luxControlBinding="value" fxFlex="nogrow"></lux-input>
+          <lux-input
+            luxName="form-dual-Bestellnr"
+            luxLabel="Bestellnr."
+            luxControlBinding="orderNo"
+            fxFlex="nogrow"
+          ></lux-input>
+          <lux-input
+            luxName="form-dual-Bestellwert"
+            luxLabel="Bestellwert"
+            luxType="text"
+            luxControlBinding="value"
+            fxFlex="nogrow"
+          ></lux-input>
           <div fxLayout="row" fxLayoutAlign="start stretch" class="lux-flex-layout-gap-10">
             <lux-datepicker luxLabel="Gültig ab" luxControlBinding="validDate" fxFlex="75"></lux-datepicker>
-            <lux-input luxLabel="Uhrzeit" luxType="time" luxControlBinding="validTime" fxFlex="25"></lux-input>
+            <lux-input
+              luxLabel="Uhrzeit"
+              luxType="time"
+              luxControlBinding="validTime"
+              fxFlex="25"
+              luxAutocomplete="off"
+            ></lux-input>
           </div>
         </div>
       </div>

--- a/src/app/demo/form/form-single-col/form-single-col.component.html
+++ b/src/app/demo/form/form-single-col/form-single-col.component.html
@@ -2,8 +2,8 @@
   <lux-card-content>
     <form [formGroup]="myGroup" #myForm>
       <div formGroupName="userInformation">
-        <lux-input luxLabel="Username" luxControlBinding="username"></lux-input>
-        <lux-input luxLabel="Passwort" luxType="password" luxControlBinding="password">
+        <lux-input luxName="username" luxLabel="Username" luxControlBinding="username"></lux-input>
+        <lux-input luxName="current-password" luxLabel="Passwort" luxType="password" luxControlBinding="password">
           <lux-input-suffix>
             <lux-icon luxIconName="fa-lock"></lux-icon>
           </lux-input-suffix>
@@ -17,12 +17,18 @@
           luxControlBinding="salutation"
         >
         </lux-autocomplete>
-        <lux-input luxLabel="E-Mail" luxControlBinding="email">
+        <lux-input luxName="email" luxLabel="E-Mail" luxControlBinding="email">
           <lux-input-suffix>
             <lux-icon luxIconName="fa-at"></lux-icon>
           </lux-input-suffix>
         </lux-input>
-        <lux-input luxLabel="Deaktiviertes Element" luxControlBinding="deactivated" [luxDisabled]="true"> </lux-input>
+        <lux-input
+          luxName="form-single_DeaktiviertesElement"
+          luxLabel="Deaktiviertes Element"
+          luxControlBinding="deactivated"
+          [luxDisabled]="true"
+        >
+        </lux-input>
         <lux-radio
           [luxOrientationVertical]="true"
           [luxOptions]="genders"
@@ -33,7 +39,14 @@
             {{ option.name }}
           </ng-template>
         </lux-radio>
-        <lux-input luxLabel="Alter" luxControlBinding="age" luxType="number" [luxNumberAlignLeft]="true"> </lux-input>
+        <lux-input
+          luxName="form-single_Alter"
+          luxLabel="Alter"
+          luxControlBinding="age"
+          luxType="number"
+          [luxNumberAlignLeft]="true"
+        >
+        </lux-input>
         <lux-autocomplete
           [luxOptions]="countries"
           luxOptionLabelProp="name"

--- a/src/app/demo/form/form-three-col/form-three-col.component.html
+++ b/src/app/demo/form/form-three-col/form-three-col.component.html
@@ -4,8 +4,8 @@
       <div fxLayout="row wrap" class="lux-flex-layout-gap-10">
         <div formGroupName="customer" fxLayout="column" fxFlex="1 0 calc(33% - 10px)">
           <h2>Kunde</h2>
-          <lux-input luxLabel="Vorname" luxControlBinding="name" fxFlex="nogrow"></lux-input>
-          <lux-input luxLabel="Nachname" luxControlBinding="surname" fxFlex="nogrow"></lux-input>
+          <lux-input luxName="first-name" luxLabel="Vorname" luxControlBinding="name" fxFlex="nogrow"></lux-input>
+          <lux-input luxName="given-name" luxLabel="Nachname" luxControlBinding="surname" fxFlex="nogrow"></lux-input>
           <lux-radio
             [luxOrientationVertical]="false"
             [luxOptions]="genders"
@@ -21,10 +21,28 @@
         <div formGroupName="address" fxLayout="column" fxFlex="1 1 auto">
           <h2>Adresse</h2>
           <div fxLayout="row" fxLayoutAlign="start stretch" class="lux-flex-layout-gap-10">
-            <lux-input luxLabel="PLZ" luxType="number" luxControlBinding="zip" fxFlex="0 0 50px"></lux-input>
-            <lux-input luxLabel="Stadt" luxType="text" luxControlBinding="town" fxFlex="1 1 auto"></lux-input>
+            <lux-input
+              luxName="postal-code"
+              luxLabel="PLZ"
+              luxType="number"
+              luxControlBinding="zip"
+              fxFlex="0 0 50px"
+            ></lux-input>
+            <lux-input
+              luxName="form-three_Stadt"
+              luxLabel="Stadt"
+              luxType="text"
+              luxControlBinding="town"
+              fxFlex="1 1 auto"
+            ></lux-input>
           </div>
-          <lux-input luxLabel="Straße" luxType="text" luxControlBinding="street" fxFlex="nogrow"></lux-input>
+          <lux-input
+            luxName="street-address"
+            luxLabel="Straße"
+            luxType="text"
+            luxControlBinding="street"
+            fxFlex="nogrow"
+          ></lux-input>
           <lux-autocomplete
             [luxOptions]="countries"
             luxOptionLabelProp="name"
@@ -39,7 +57,13 @@
         </div>
         <div formGroupName="feedback" fxLayout="column" fxFlex="1 0 auto">
           <h2>Feedback</h2>
-          <lux-input luxLabel="Bewertung" luxControlBinding="rating" luxType="text" fxFlex="nogrow"></lux-input>
+          <lux-input
+            luxName="form-three_Bewertung"
+            luxLabel="Bewertung"
+            luxControlBinding="rating"
+            luxType="text"
+            fxFlex="nogrow"
+          ></lux-input>
           <lux-checkbox luxLabel="Anonymisieren" luxControlBinding="anonymous" fxFlex="nogrow"></lux-checkbox>
         </div>
       </div>

--- a/src/app/modules/lux-common/lux-table/lux-table.component.html
+++ b/src/app/modules/lux-common/lux-table/lux-table.component.html
@@ -11,6 +11,7 @@
   <!-- Input-Feld für das Filtern der Datensätze dieser Tabelle -->
   <lux-input
     class="lux-table-filter"
+    luxAutocomplete="off"
     [luxTagId]="luxFilterText"
     [luxLabel]="luxFilterText"
     (luxValueChange)="filtered$.next($event)"

--- a/src/app/modules/lux-common/lux-table/lux-table.component.ts
+++ b/src/app/modules/lux-common/lux-table/lux-table.component.ts
@@ -27,6 +27,7 @@ import { LuxMediaQueryObserverService } from '../../lux-util/lux-media-query-obs
 import { LuxTableColumnComponent } from './lux-table-subcomponents/lux-table-column.component';
 import { LuxConsoleService } from '../../lux-util/lux-console.service';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { LuxInputComponent } from '../../lux-form/lux-input/lux-input.component';
 
 @Component({
   selector: 'lux-table',
@@ -85,6 +86,7 @@ export class LuxTableComponent implements OnInit, AfterViewInit, DoCheck, OnDest
   @ViewChild(MatSort, { static: true }) sort: MatSort;
   @ViewChild('paginator', { read: ElementRef, static: true }) paginatorElement: ElementRef;
   @ViewChild('filter', { read: ElementRef, static: true }) filterElement: ElementRef;
+  @ViewChild('filter', { static: true }) filterComponent: LuxInputComponent;
   @ViewChild('tableContainer', { read: ElementRef, static: true }) tableContainerElement: ElementRef;
   @ContentChildren(LuxTableColumnComponent) tableColumns: QueryList<LuxTableColumnComponent>;
 

--- a/src/app/modules/lux-form/lux-form-control/lux-form-directives/lux-name/lux-name-directive.directive.ts
+++ b/src/app/modules/lux-form/lux-form-control/lux-form-directives/lux-name/lux-name-directive.directive.ts
@@ -1,0 +1,25 @@
+import {Directive, ElementRef, Input, Renderer2} from '@angular/core';
+
+@Directive({
+  selector: '[luxNameAttr]'
+})
+export class LuxNameDirectiveDirective {
+  _luxNameAttr: string;
+
+  @Input()
+  get luxNameAttr() {
+    return this._luxNameAttr;
+  }
+
+  set luxNameAttr(name: string) {
+    this._luxNameAttr = name;
+
+    if (this._luxNameAttr) {
+      this.renderer.setAttribute(this.elementRef.nativeElement, 'name', this._luxNameAttr);
+    } else {
+      this.renderer.removeAttribute(this.elementRef.nativeElement, 'name');
+    }
+  }
+
+  constructor(protected elementRef: ElementRef, protected renderer: Renderer2) {}
+}

--- a/src/app/modules/lux-form/lux-form-model/lux-form-input-base.class.ts
+++ b/src/app/modules/lux-form/lux-form-model/lux-form-input-base.class.ts
@@ -17,6 +17,7 @@ export abstract class LuxFormInputBaseClass extends LuxFormComponentBase {
   @Input() luxPlaceholder: string = '';
   @Input() luxReadonly: boolean;
   @Input() luxTagId: string;
+  @Input() luxName: string;
   @Input() luxAutocomplete: string = 'on';
 
   get luxValue(): string {

--- a/src/app/modules/lux-form/lux-form.module.ts
+++ b/src/app/modules/lux-form/lux-form.module.ts
@@ -44,6 +44,7 @@ import { LuxTextareaComponent } from './lux-textarea/lux-textarea.component';
 import { LuxToggleComponent } from './lux-toggle/lux-toggle.component';
 import { LuxFileCaptureDirective } from './lux-file/lux-file-model/lux-file-capture.directive';
 import { LuxMaxLengthDirective } from './lux-form-control/lux-form-directives/lux-maxlength/lux-max-length.directive';
+import { LuxNameDirectiveDirective } from './lux-form-control/lux-form-directives/lux-name/lux-name-directive.directive';
 
 @NgModule({
   declarations: [
@@ -68,7 +69,8 @@ import { LuxMaxLengthDirective } from './lux-form-control/lux-form-directives/lu
     LuxFileInputComponent,
     LuxFileProgressComponent,
     LuxFileCaptureDirective,
-    LuxMaxLengthDirective
+    LuxMaxLengthDirective,
+    LuxNameDirectiveDirective
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/lux-form/lux-input/lux-input.component.html
+++ b/src/app/modules/lux-form/lux-input/lux-input.component.html
@@ -7,6 +7,7 @@
       fxFlex="auto"
       matInput
       luxTagIdHandler
+      [luxNameAttr]="luxName"
       [luxTagId]="luxTagId"
       [placeholder]="luxPlaceholder"
       [type]="luxType"
@@ -28,6 +29,7 @@
       fxFlex="auto"
       matInput
       luxTagIdHandler
+      [luxNameAttr]="luxName"
       [luxTagId]="luxTagId"
       [placeholder]="luxPlaceholder"
       type="number"

--- a/src/app/modules/lux-form/lux-textarea/lux-textarea.component.html
+++ b/src/app/modules/lux-form/lux-textarea/lux-textarea.component.html
@@ -2,6 +2,7 @@
   <textarea
     matInput
     luxTagIdHandler
+    [luxNameAttr]="luxName"
     [luxTagId]="luxTagId"
     [placeholder]="luxPlaceholder"
     [formControl]="formControl"


### PR DESCRIPTION
- **lux-table**: Die LuxTable stellt jetzt den Filter als LuxInputComponent zur Verfügung.
- **lux-table**: Der Defaultwert für das Autocomplete-Attribut des Tabellenfilters ist jetzt "off".
- **lux-input**: Das Attribut "luxName" hinzugefügt.
- **lux-textarea**: Das Attribut "luxName" hinzugefügt.
- In den Demos das Attribut "luxName" für alle Eingabefelder gesetzt.