### PR TITLE
Issue 14: lux-progress hat 4px padding zu viel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 1.9.3
+- **lux-progress**: Überflüssiges Padding entfernt. [Issue 14](https://github.com/IHK-GfI/lux-components/issues/14)
+
 # Version 1.9.2
 ## New
 - **lux-app-header**: Im Header kann jetzt auch ein Bild angegeben werden. [Issue 11](https://github.com/IHK-GfI/lux-components/issues/11)

--- a/src/app/modules/lux-common/lux-progress/lux-progress.component.html
+++ b/src/app/modules/lux-common/lux-progress/lux-progress.component.html
@@ -1,4 +1,8 @@
-<div [class]="animDurationCSS" [ngSwitch]="luxType" [ngClass]="['lux-progress-' + luxSize]" style="padding: 4px">
+<div
+  [class]="animDurationCSS"
+  [ngSwitch]="luxType"
+  [ngClass]="['lux-progress-' + luxSize, luxType === 'Spinner' ? 'spinner-padding' : '']"
+>
   <ng-container *ngSwitchCase="'Progressbar'">
     <mat-progress-bar
       luxTagIdHandler

--- a/src/app/modules/lux-common/lux-progress/lux-progress.component.scss
+++ b/src/app/modules/lux-common/lux-progress/lux-progress.component.scss
@@ -37,6 +37,10 @@ $animationDuration: 8s;
   }
 }
 
+.spinner-padding {
+  padding: 6px;
+}
+
 mat-progress-spinner {
   background: transparent !important;
 }


### PR DESCRIPTION
- Das 4px-Padding beim lux-progress wurde entfernt.
- Das 6px-Padding beim lux-spinner wird benötigt, da bei älteren Browsern sonst ein unschöner Scrollbalken eingeblendet wird.