### PR TITLE
Issue 13: Datumänderung per Tasteneingabe im IE nicht möglich

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.9.3
+## Bug Fixes
+- **lux-datepicker**: Datumänderung per Tasteneingabe im IE nicht möglich. [Issue 13](https://github.com/IHK-GfI/lux-components/issues/13)
+
 # Version 1.9.2
 ## New
 - **lux-app-header**: Im Header kann jetzt auch ein Bild angegeben werden. [Issue 11](https://github.com/IHK-GfI/lux-components/issues/11)

--- a/src/app/modules/lux-form/lux-datepicker/lux-datepicker-adapter.ts
+++ b/src/app/modules/lux-form/lux-datepicker/lux-datepicker-adapter.ts
@@ -34,6 +34,16 @@ export class LuxDatepickerAdapter extends NativeDateAdapter {
 
   parse(value: string): Date | null {
     if (value) {
+      if (LuxUtil.isIE()) {
+        // IE-Problem: Das Datum (als String) im IE enthält manchmal unsichtbare Steuerzeichen, die verhindern,
+        // dass das Datum korrekt von den RegEx-Ausdrücken erkannt wird. Aus diesem Grund werden hier diese
+        // unsichtbaren Steuerzeichen entfernt.
+        const ieValue = LuxUtil.stringWithoutASCIIChars(value);
+        if (value !== ieValue) {
+          value = ieValue;
+        }
+      }
+
       // Prüfen, ob der Wert ein ISO-String ist
       if (LuxUtil.ISO_8601_FULL.test(value)) {
         return new Date(value);

--- a/src/app/modules/lux-form/lux-datepicker/lux-datepicker.component.spec.ts
+++ b/src/app/modules/lux-form/lux-datepicker/lux-datepicker.component.spec.ts
@@ -9,9 +9,9 @@ import { AbstractControl, FormBuilder, FormGroup, ValidatorFn, Validators } from
 import { LuxOverlayHelper } from '../../lux-util/testing/lux-test-overlay-helper';
 import { of } from 'rxjs';
 import { delay } from 'rxjs/operators';
+import { LuxUtil } from '../../lux-util/lux-util';
 
 describe('LuxDatepickerComponent', () => {
-
   beforeEach(async () => {
     LuxTestHelper.configureTestModule(
       [LuxConsoleService],
@@ -55,7 +55,7 @@ describe('LuxDatepickerComponent', () => {
 
       // Nachbedingungen testen
       const datepickerEl = fixture.debugElement.query(By.css('input'));
-      expect(LuxTestHelper.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
         '01.01.2019',
         'Nachbedingung 2'
       );
@@ -109,7 +109,7 @@ describe('LuxDatepickerComponent', () => {
       utcNullifiedDate.setUTCFullYear(2015, 5, 10);
       utcNullifiedDate.setUTCHours(0);
       const datepickerEl = fixture.debugElement.query(By.css('input'));
-      expect(LuxTestHelper.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
         '10.06.2015',
         'Nachbedingung 1'
       );
@@ -133,7 +133,7 @@ describe('LuxDatepickerComponent', () => {
       utcNullifiedDate.setUTCFullYear(2015, 5, 10);
       utcNullifiedDate.setUTCHours(0);
       let datepickerEl = fixture.debugElement.query(By.css('input'));
-      expect(LuxTestHelper.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
         '10.06.2015',
         'Nachbedingung 1'
       );
@@ -146,7 +146,7 @@ describe('LuxDatepickerComponent', () => {
       // Nachbedingungen testen
       utcNullifiedDate.setUTCMonth(6);
       datepickerEl = fixture.debugElement.query(By.css('input'));
-      expect(LuxTestHelper.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
         '10.07.2015',
         'Nachbedingung 3'
       );
@@ -244,9 +244,9 @@ describe('LuxDatepickerComponent', () => {
       flush();
 
       expect(datepickerComponent['dateAdapter']['locale']).toEqual('de-DE');
-      expect(
-        LuxTestHelper.stringWithoutASCIIChars(fixture.debugElement.query(By.css('input')).nativeElement.value)
-      ).toEqual('05.03.2019');
+      expect(LuxUtil.stringWithoutASCIIChars(fixture.debugElement.query(By.css('input')).nativeElement.value)).toEqual(
+        '05.03.2019'
+      );
     }));
 
     it('LuxValue Simple', fakeAsync(() => {
@@ -260,7 +260,7 @@ describe('LuxDatepickerComponent', () => {
 
       // Nachbedingungen testen
       const datepickerEl = fixture.debugElement.query(By.css('input'));
-      expect(LuxTestHelper.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
         '10.07.2015',
         'Nachbedingung 1'
       );
@@ -280,7 +280,7 @@ describe('LuxDatepickerComponent', () => {
 
       // Nachbedingungen testen
       const datepickerEl = fixture.debugElement.query(By.css('input'));
-      expect(LuxTestHelper.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
         '10.06.2015',
         'Nachbedingung 1'
       );
@@ -299,7 +299,7 @@ describe('LuxDatepickerComponent', () => {
 
       // Nachbedingungen testen
       const datepickerEl = fixture.debugElement.query(By.css('input'));
-      expect(LuxTestHelper.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
         '06/10/2015',
         'Nachbedingung 1'
       );
@@ -318,7 +318,7 @@ describe('LuxDatepickerComponent', () => {
 
       // Nachbedingungen testen
       const datepickerEl = fixture.debugElement.query(By.css('input'));
-      expect(LuxTestHelper.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
         '10/06/2015',
         'Nachbedingung 1'
       );

--- a/src/app/modules/lux-markdown/lux-markdown/lux-markdown.component.spec.ts
+++ b/src/app/modules/lux-markdown/lux-markdown/lux-markdown.component.spec.ts
@@ -5,6 +5,7 @@ import { LuxHtmlModule } from '../../lux-html/lux-html.module';
 import { By } from '@angular/platform-browser';
 import marked from 'marked/lib/marked';
 import { LuxTestHelper } from '../../lux-util/testing/lux-test-helper';
+import { LuxUtil } from '../../lux-util/lux-util';
 
 describe('LuxMarkdownComponent', () => {
   let component: LuxMarkdownComponent;
@@ -36,13 +37,11 @@ describe('LuxMarkdownComponent', () => {
     fixture.detectChanges();
 
     // Die HTML-Daten sollten unverändert in die Component übernommen worden sein.
-    expect(LuxTestHelper.stringWithoutASCIIChars(component.luxData)).toEqual('<p>' + htmlData + '</p>');
+    expect(LuxUtil.stringWithoutASCIIChars(component.luxData)).toEqual('<p>' + htmlData + '</p>');
 
     // Gerendert werden dürfen die schädlichen Tags allerdings nicht!
     expect(
-      LuxTestHelper.stringWithoutASCIIChars(
-        fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML
-      )
+      LuxUtil.stringWithoutASCIIChars(fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML)
     ).toEqual('<p>Lorem ipsum  dolor sit amet</p>');
   });
 
@@ -53,44 +52,36 @@ describe('LuxMarkdownComponent', () => {
     component.luxData = '# Lorem ipsum';
     fixture.detectChanges();
 
-    expect(LuxTestHelper.stringWithoutASCIIChars(component.luxData)).toEqual('<h1>Lorem ipsum</h1>');
+    expect(LuxUtil.stringWithoutASCIIChars(component.luxData)).toEqual('<h1>Lorem ipsum</h1>');
     expect(
-      LuxTestHelper.stringWithoutASCIIChars(
-        fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML
-      )
+      LuxUtil.stringWithoutASCIIChars(fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML)
     ).toEqual('<h1>Lorem ipsum</h1>');
 
     // Teste h2
     component.luxData = '## Lorem ipsum';
     fixture.detectChanges();
 
-    expect(LuxTestHelper.stringWithoutASCIIChars(component.luxData)).toEqual('<h2>Lorem ipsum</h2>');
+    expect(LuxUtil.stringWithoutASCIIChars(component.luxData)).toEqual('<h2>Lorem ipsum</h2>');
     expect(
-      LuxTestHelper.stringWithoutASCIIChars(
-        fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML
-      )
+      LuxUtil.stringWithoutASCIIChars(fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML)
     ).toEqual('<h2>Lorem ipsum</h2>');
 
     // Teste h3
     component.luxData = '### Lorem ipsum';
     fixture.detectChanges();
 
-    expect(LuxTestHelper.stringWithoutASCIIChars(component.luxData)).toEqual('<h3>Lorem ipsum</h3>');
+    expect(LuxUtil.stringWithoutASCIIChars(component.luxData)).toEqual('<h3>Lorem ipsum</h3>');
     expect(
-      LuxTestHelper.stringWithoutASCIIChars(
-        fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML
-      )
+      LuxUtil.stringWithoutASCIIChars(fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML)
     ).toEqual('<h3>Lorem ipsum</h3>');
 
     // Teste h4
     component.luxData = '#### Lorem ipsum';
     fixture.detectChanges();
 
-    expect(LuxTestHelper.stringWithoutASCIIChars(component.luxData)).toEqual('<h4>Lorem ipsum</h4>');
+    expect(LuxUtil.stringWithoutASCIIChars(component.luxData)).toEqual('<h4>Lorem ipsum</h4>');
     expect(
-      LuxTestHelper.stringWithoutASCIIChars(
-        fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML
-      )
+      LuxUtil.stringWithoutASCIIChars(fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML)
     ).toEqual('<h4>Lorem ipsum</h4>');
   });
 
@@ -100,13 +91,11 @@ describe('LuxMarkdownComponent', () => {
     component.luxData = '[IHK-GfI](https://www.ihk-gfi.de)';
     fixture.detectChanges();
 
-    expect(LuxTestHelper.stringWithoutASCIIChars(component.luxData)).toEqual(
+    expect(LuxUtil.stringWithoutASCIIChars(component.luxData)).toEqual(
       '<p><a href="https://www.ihk-gfi.de">IHK-GfI</a></p>'
     );
     expect(
-      LuxTestHelper.stringWithoutASCIIChars(
-        fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML
-      )
+      LuxUtil.stringWithoutASCIIChars(fixture.debugElement.query(By.css('lux-html > div')).nativeElement.innerHTML)
     ).toEqual('<p><a href="https://www.ihk-gfi.de">IHK-GfI</a></p>');
   });
 

--- a/src/app/modules/lux-util/lux-util.ts
+++ b/src/app/modules/lux-util/lux-util.ts
@@ -370,4 +370,14 @@ export class LuxUtil {
   private static getKey(event: KeyboardEvent): string | number {
     return event.key || event.keyCode;
   }
+
+  /**
+   * Entfernt nicht-ASCII-Chars aus dem String (Beim IE wichtig, dieser fügt gerne versteckte Steuerzeichen
+   * in Input-Feldern an die Strings).
+   * @param dateString
+   */
+  public static stringWithoutASCIIChars(dateString: string): string {
+    const exp = new RegExp('[^A-Za-z 0-9 \\.,\\?""!@#\\$%\\^&\\*\\(\\)-_=\\+;:<>\\/\\\\\\|\\}\\{\\[\\]`~]*', 'g');
+    return dateString.replace(exp, '');
+  }
 }

--- a/src/app/modules/lux-util/testing/lux-test-helper.ts
+++ b/src/app/modules/lux-util/testing/lux-test-helper.ts
@@ -282,16 +282,6 @@ export class LuxTestHelper {
   }
 
   /**
-   * Entfernt nicht-ASCII-Chars aus dem String (Beim IE wichtig, dieser fügt gerne versteckte Steuerzeichen
-   * in Input-Feldern an die Strings).
-   * @param dateString
-   */
-  public static stringWithoutASCIIChars(dateString: string): string {
-    const exp = new RegExp('[^A-Za-z 0-9 \\.,\\?""!@#\\$%\\^&\\*\\(\\)-_=\\+;:<>\\/\\\\\\|\\}\\{\\[\\]`~]*', 'g');
-    return dateString.replace(exp, '');
-  }
-
-  /**
    * Konfiguriert das TestModul für eine Testsuite, kann dabei Provider und Komponenten (Deklarationen) entgegennehmen.
    * @param providers
    * @param declarations


### PR DESCRIPTION
-  Das Datum (als String) im IE enthielt manchmal unsichtbare Steuerzeichen, die verhinderten, dass das Datum korrekt erkannt wurde.