### PR TITLE
Issue_17: Events im App-Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Version 1.9.3
+## New
+- **lux-app-header**: Click-Event, welches beim KLick auf den App-Titel, das App-Icon (falls vorhanden) oder das App-Image (falls vorhanden) ausgelöst wird, hinzugefügt. [Issue 17](https://github.com/IHK-GfI/lux-components/issues/17)
+
 ## Bug Fixes
 - **lux-datepicker**: Datumänderung per Tasteneingabe im IE nicht möglich. [Issue 13](https://github.com/IHK-GfI/lux-components/issues/13)
 - **lux-progress**: Überflüssiges Padding entfernt. [Issue 14](https://github.com/IHK-GfI/lux-components/issues/14)

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,6 +4,7 @@
     luxAppTitleShort="Components"
     luxUserName="Max Mustermann"
     luxIconName="far fa-lightbulb"
+    (luxClicked)="router.navigate(['/']);"
   >
     <lux-side-nav luxDashboardLink="https://github.com/IHK-GfI/lux-components/wiki" [luxOpenLinkBlank]="true">
       <lux-side-nav-header>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,7 +15,7 @@ export class AppComponent implements OnInit {
   window = window;
 
   constructor(
-    private router: Router,
+    public router: Router,
     private linkService: LuxAppFooterLinkService,
     private buttonService: LuxAppFooterButtonService,
     private snackbarService: LuxSnackbarService,

--- a/src/app/modules/lux-layout/lux-app-header/lux-app-header.component.html
+++ b/src/app/modules/lux-layout/lux-app-header/lux-app-header.component.html
@@ -27,18 +27,40 @@
 
       <span fxLayout="row" fxLayoutAlign="center center" class="lux-nowrap lux-header-title" fxFlex="auto">
         <lux-icon
+          style="padding: 6px 5px"
           [luxIconName]="luxIconName"
-          class="lux-pr-3"
+          [ngClass]="{ 'lux-cursor': hasOnClickedListener, focused: hasOnClickedListener }"
+          (click)="onClicked($event)"
+          (keydown.enter)="onClicked($event)"
+          (keydown.space)="onClicked($event)"
+          [attr.role]="hasOnClickedListener ? 'link' : null"
+          [attr.tabindex]="hasOnClickedListener ? '0' : null"
           *ngIf="luxIconName && !sideNav && !mobileHelperService.isMobile()"
         ></lux-icon>
         <lux-image
+          style="padding: 0 5px"
           [luxImageSrc]="luxImageSrc"
           [luxImageHeight]="luxImageHeight"
           [luxImageWidth]="isIE && luxImageSrc && luxImageSrc.endsWith('.svg') ? '100%' : 'auto'"
-          class="lux-pr-3"
+          [ngClass]="{ 'lux-cursor': hasOnClickedListener, focused: hasOnClickedListener }"
+          (click)="onClicked($event)"
+          (keydown.enter)="onClicked($event)"
+          (keydown.space)="onClicked($event)"
+          [attr.role]="hasOnClickedListener ? 'link' : null"
+          [attr.tabindex]="hasOnClickedListener ? '0' : null"
           *ngIf="luxImageSrc && !sideNav && !mobileHelperService.isMobile()"
         ></lux-image
-        ><span fxFlex="auto">{{ mobileHelperService.isMobile() ? luxAppTitleShort : luxAppTitle }}</span>
+        ><span
+          fxFlex="auto"
+          style="padding: 10px 5px"
+          (click)="onClicked($event)"
+          (keydown.enter)="onClicked($event)"
+          (keydown.space)="onClicked($event)"
+          [attr.role]="hasOnClickedListener ? 'link' : null"
+          [attr.tabindex]="hasOnClickedListener ? '0' : null"
+          [ngClass]="{ 'lux-cursor': hasOnClickedListener, focused: hasOnClickedListener }"
+          >{{ mobileHelperService.isMobile() ? luxAppTitleShort : luxAppTitle }}</span
+        >
       </span>
     </div>
   </div>

--- a/src/app/modules/lux-layout/lux-app-header/lux-app-header.component.scss
+++ b/src/app/modules/lux-layout/lux-app-header/lux-app-header.component.scss
@@ -1,5 +1,19 @@
 @import '../../../../theming/luxtheme';
 
+.focused {
+  &:focus {
+    outline-width: 0 !important;
+    outline-style: unset;
+    background-color: $lux-focused-color !important;
+    border-radius: 4px;
+  }
+
+  &:hover {
+    background-color: $lux-hover-color !important;
+    border-radius: 4px;
+  }
+}
+
 :host {
   flex: 0 0 auto;
   max-height: 65px;
@@ -120,7 +134,6 @@
       min-width: 45px;
       width: 45px;
       max-width: 45px;
-      margin-right: 8px;
 
       ::ng-deep button {
         min-width: 45px;

--- a/src/app/modules/lux-layout/lux-app-header/lux-app-header.component.spec.ts
+++ b/src/app/modules/lux-layout/lux-app-header/lux-app-header.component.spec.ts
@@ -9,7 +9,6 @@ import { Router } from '@angular/router';
 import { LuxConsoleService } from '../../lux-util/lux-console.service';
 
 describe('LuxAppHeaderComponent', () => {
-
   beforeEach(async () => {
     LuxTestHelper.configureTestModule(
       [
@@ -20,8 +19,60 @@ describe('LuxAppHeaderComponent', () => {
           useClass: MockMasterDetailHelperService
         }
       ],
-      [MockAppHeaderComponent]
+      [
+        MockAppHeaderComponent,
+        MockLabelClickedAppHeaderComponent,
+        MockIconClickedAppHeaderComponent,
+        MockImageClickedAppHeaderComponent
+      ]
     );
+  });
+
+  describe('luxClicked', () => {
+    it('Label im App-Header sollte angeklickt werden können', fakeAsync(() => {
+      const fixture = TestBed.createComponent(MockLabelClickedAppHeaderComponent);
+      LuxTestHelper.wait(fixture);
+
+      const element = fixture.debugElement.query(By.css('span.lux-cursor'));
+      const onClickSpy = spyOn(fixture.componentInstance, 'onClicked');
+
+      element.nativeElement.click();
+      fixture.detectChanges();
+
+      expect(element).toBeDefined();
+      expect(onClickSpy).toHaveBeenCalled();
+      expect(element.classes['lux-cursor']).toBeTrue();
+    }));
+
+    it('Icon im App-Header sollte angeklickt werden können', fakeAsync(() => {
+      const fixture = TestBed.createComponent(MockIconClickedAppHeaderComponent);
+      LuxTestHelper.wait(fixture);
+
+      const element = fixture.debugElement.query(By.css('lux-icon.lux-cursor'));
+      const onClickSpy = spyOn(fixture.componentInstance, 'onClicked');
+
+      element.nativeElement.click();
+      fixture.detectChanges();
+
+      expect(element).toBeDefined();
+      expect(onClickSpy).toHaveBeenCalled();
+      expect(element.classes['lux-cursor']).toBeTrue();
+    }));
+
+    it('Image im App-Header sollte angeklickt werden können', fakeAsync(() => {
+      const fixture = TestBed.createComponent(MockImageClickedAppHeaderComponent);
+      LuxTestHelper.wait(fixture);
+
+      const element = fixture.debugElement.query(By.css('lux-image.lux-cursor'));
+      const onClickSpy = spyOn(fixture.componentInstance, 'onClicked');
+
+      element.nativeElement.click();
+      fixture.detectChanges();
+
+      expect(element).toBeDefined();
+      expect(onClickSpy).toHaveBeenCalled();
+      expect(element.classes['lux-cursor']).toBeTrue();
+    }));
   });
 
   describe('ohne lux-side-nav und lux-app-header-right-nav', () => {
@@ -587,6 +638,43 @@ describe('LuxAppHeaderComponent', () => {
     }));
   });
 });
+
+@Component({
+  template: `
+    <lux-app-header (luxClicked)="onClicked()" luxAppTitle="MyClickTitle" luxAppTitleShort="MyClick"></lux-app-header>
+  `
+})
+class MockLabelClickedAppHeaderComponent {
+  onClicked() {}
+}
+
+@Component({
+  template: `
+    <lux-app-header
+      (luxClicked)="onClicked()"
+      luxImageSrc="/assets/png/example.png"
+      luxAppTitle="MyClickTitle"
+      luxAppTitleShort="MyClick"
+    ></lux-app-header>
+  `
+})
+class MockImageClickedAppHeaderComponent {
+  onClicked() {}
+}
+
+@Component({
+  template: `
+    <lux-app-header
+      (luxClicked)="onClicked()"
+      luxIconName="fa fas-user"
+      luxAppTitle="MyClickTitle"
+      luxAppTitleShort="MyClick"
+    ></lux-app-header>
+  `
+})
+class MockIconClickedAppHeaderComponent {
+  onClicked() {}
+}
 
 @Component({
   template: `

--- a/src/app/modules/lux-layout/lux-app-header/lux-app-header.component.ts
+++ b/src/app/modules/lux-layout/lux-app-header/lux-app-header.component.ts
@@ -1,5 +1,15 @@
 // tslint:disable:max-line-length
-import { Component, ContentChild, ElementRef, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import {
+  Component,
+  ContentChild,
+  ElementRef, EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 import { LuxConsoleService } from '../../lux-util/lux-console.service';
 import { LuxMasterDetailMobileHelperService } from '../lux-master-detail/lux-master-detail-mobile-helper.service';
 import { LuxSideNavComponent } from './lux-app-header-subcomponents/lux-side-nav/lux-side-nav.component';
@@ -20,12 +30,15 @@ export class LuxAppHeaderComponent implements OnInit, OnChanges {
   @Input() luxImageSrc: string;
   @Input() luxImageHeight = '55px';
 
+  @Output() luxClicked: EventEmitter<any> = new EventEmitter();
+
   isMasterOpen: boolean;
   isMasterDetailAvailable: boolean;
   masterHasValue: boolean;
 
   userNameShort: string;
   isIE = LuxUtil.isIE();
+  hasOnClickedListener: boolean;
 
   @ViewChild('customTrigger', { read: ElementRef }) customTrigger: ElementRef;
 
@@ -56,7 +69,11 @@ export class LuxAppHeaderComponent implements OnInit, OnChanges {
     });
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    if (this.luxClicked.observers && this.luxClicked.observers.length > 0) {
+      this.hasOnClickedListener = true;
+    }
+  }
 
   ngOnChanges(simpleChanges: SimpleChanges) {
     if (simpleChanges.luxUserName) {
@@ -80,6 +97,10 @@ export class LuxAppHeaderComponent implements OnInit, OnChanges {
 
   onMenuClosed() {
     this.customTrigger.nativeElement.focus();
+  }
+
+  onClicked(event: any) {
+    this.luxClicked.emit(event);
   }
 
   private generateUserNameShort(): string {


### PR DESCRIPTION
## New
- **lux-app-header**: Click-Event, welches beim KLick auf den App-Titel, das App-Icon (falls vorhanden) oder das App-Image (falls vorhanden) ausgelöst wird, hinzugefügt. [Issue 17](https://github.com/IHK-GfI/lux-components/issues/17)