### PR TITLE
Issue_20: Datepickerpopup zeigt immer Sonntag als ersten Wochentag an

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,9 +1,8 @@
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import {BrowserModule, HammerModule} from '@angular/platform-browser';
+import { BrowserModule, HammerModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppRoutingModule } from './app-routing.module';
-
 import { AppComponent } from './app.component';
 import { HomeModule } from './demo/home/home.module';
 import { LuxActionModule } from './modules/lux-action/lux-action.module';
@@ -32,6 +31,12 @@ import { ExampleBaseModule } from './demo/example-base/example-base.module';
 import { LuxCommonModule } from './modules/lux-common/lux-common.module';
 import { LuxErrorModule } from './modules/lux-error/lux-error.module';
 import 'hammerjs';
+import { registerLocaleData } from '@angular/common';
+import localeDE from '@angular/common/locales/de';
+import localeDeExtra from '@angular/common/locales/extra/de';
+import { LOCALE_ID } from '@angular/core';
+
+registerLocaleData(localeDE, localeDeExtra);
 
 const myConfiguration: LuxComponentsConfigParameters = {
   generateLuxTagIds: environment.generateLuxTagIds,
@@ -68,6 +73,7 @@ const myConfiguration: LuxComponentsConfigParameters = {
   ],
   entryComponents: [LuxSnackbarComponent, LuxFilePreviewComponent],
   providers: [
+    { provide: LOCALE_ID, useValue: 'de-DE' },
     LuxAppFooterButtonService,
     LuxAppFooterLinkService,
     LuxSnackbarService,

--- a/src/app/modules/lux-form/lux-datepicker/lux-datepicker-adapter.ts
+++ b/src/app/modules/lux-form/lux-datepicker/lux-datepicker-adapter.ts
@@ -2,6 +2,7 @@ import { NativeDateAdapter } from '@angular/material/core';
 import { Injectable } from '@angular/core';
 import { LuxUtil } from '../../lux-util/lux-util';
 import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+import { getLocaleFirstDayOfWeek } from '@angular/common';
 
 @Injectable()
 export class LuxDatepickerAdapter extends NativeDateAdapter {
@@ -61,6 +62,24 @@ export class LuxDatepickerAdapter extends NativeDateAdapter {
       return <any>value;
     }
     return null;
+  }
+
+  getFirstDayOfWeek(): number {
+    let startDay;
+    try {
+      startDay = getLocaleFirstDayOfWeek(this.locale);
+    } catch (e) {
+      startDay = super.getFirstDayOfWeek();
+
+      console.warn(
+        `Für die Locale '${
+          this.locale
+        }' fehlt der Aufruf 'registerLocaleData(...)' aus dem Package '@angular/common' in der Datei 'app.modules.ts'. Die Woche startet mit dem Defaultwert '${
+          this.getDayOfWeekNames('long')[startDay]
+        }'.'`
+      );
+    }
+    return startDay;
   }
 
   /**


### PR DESCRIPTION
- Der lux-datepicker-adapter liefert jetzt den ersten Wochentag abhängig von der Locale (z.B. de-DE=Montag, en-US=Sonntag) zurück.