### PR TITLE
Issue_28: lux‐datepicker: luxMaxDate greift bei 5- oder 6-stelligen J…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.9.5
+## Bug Fixes
+- **lux-datepicker**: luxMaxDate greift bei 5- oder 6-stelligen Jahreszahlen nicht und luxValueChange empfängt event. [Issue 28](https://github.com/IHK-GfI/lux-components/issues/28)
+
 # Version 1.9.4
 ## New
 - **Demo**: Demoseiten für den Datenschutz und Impressum hinzugefügt. [Issue 32](https://github.com/IHK-GfI/lux-components/issues/32)

--- a/src/app/modules/lux-form/lux-datepicker/lux-datepicker-adapter.ts
+++ b/src/app/modules/lux-form/lux-datepicker/lux-datepicker-adapter.ts
@@ -90,7 +90,7 @@ export class LuxDatepickerAdapter extends NativeDateAdapter {
   private getUTCNulled_ddMMYYYY(dateString: string, separator: string) {
     const splitDate = dateString.split(separator);
     const tempDate = new Date(0);
-    tempDate.setUTCFullYear(+splitDate[2], +splitDate[1] - 1, +splitDate[0]);
+    tempDate.setUTCFullYear(+splitDate[2], this.calculateMonth(+splitDate[1]), +splitDate[0]);
     return tempDate;
   }
 
@@ -102,7 +102,7 @@ export class LuxDatepickerAdapter extends NativeDateAdapter {
   private getUTCNulled_YYYYMMdd(dateString: string, separator: string) {
     const splitDate = dateString.split(separator);
     const tempDate = new Date(0);
-    tempDate.setUTCFullYear(+splitDate[0], +splitDate[1] - 1, +splitDate[2]);
+    tempDate.setUTCFullYear(+splitDate[0], this.calculateMonth(+splitDate[1]), +splitDate[2]);
     return tempDate;
   }
 
@@ -114,11 +114,31 @@ export class LuxDatepickerAdapter extends NativeDateAdapter {
   private getUTCNulled_MMddYYY(dateString: string, separator: string) {
     const splitDate = dateString.split(separator);
     const tempDate = new Date(0);
-    tempDate.setUTCFullYear(+splitDate[2], +splitDate[0] - 1, +splitDate[1]);
+    tempDate.setUTCFullYear(+splitDate[2], this.calculateMonth(+splitDate[0]), +splitDate[1]);
     return tempDate;
   }
 
   isValid(date: any) {
-    return LuxUtil.isDate(date);
+    return LuxUtil.isDate(date) && this.isValidYear(date);
+  }
+
+  private calculateMonth(month: number) {
+    let newMonth = month;
+
+    if (month <= 0) {
+      newMonth = 0;
+    } else if (month >= 12) {
+      newMonth = 11;
+    } else {
+      newMonth = month - 1;
+    }
+
+    return newMonth;
+  }
+
+  private isValidYear(date: any) {
+    // Prüfen, ob das Jahr auch aus genau vier Stellen (z.B. 2020) besteht.
+    // Ohne diesen Check würden auch 5- oder 6-stellige Jahreszahlen akzeptiert.
+    return date.getFullYear() && date.getFullYear().toString().length === 4;
   }
 }

--- a/src/app/modules/lux-form/lux-datepicker/lux-datepicker.component.spec.ts
+++ b/src/app/modules/lux-form/lux-datepicker/lux-datepicker.component.spec.ts
@@ -153,6 +153,28 @@ describe('LuxDatepickerComponent', () => {
       expect(datepickerComponent.luxValue).toEqual(utcNullifiedDate.toISOString(), `Nachbedingung 4`);
     }));
 
+    it('Sollte das Datum 01.0.2020 in 01.01.2020 umwandeln und nicht in 01.12.2019', fakeAsync(() => {
+      fixture.detectChanges();
+      // Vorbedingungen testen
+      expect(testComponent.formControl.value).toBeFalsy(`Vorbedingung 1`);
+      expect(datepickerComponent.luxValue).toBeFalsy(`Vorbedingung 2`);
+
+      // Änderungen durchführen
+      testComponent.formControl.setValue('01.0.2020');
+      LuxTestHelper.wait(fixture);
+
+      // Nachbedingungen testen
+      const utcNullifiedDate = new Date(0);
+      utcNullifiedDate.setUTCFullYear(2020, 0, 1);
+      utcNullifiedDate.setUTCHours(0);
+      const datepickerEl = fixture.debugElement.query(By.css('input'));
+      expect(LuxUtil.stringWithoutASCIIChars(datepickerEl.nativeElement.value)).toEqual(
+        '01.01.2020',
+        'Nachbedingung 1'
+      );
+      expect(datepickerComponent.luxValue).toEqual(utcNullifiedDate.toISOString(), `Nachbedingung 2`);
+    }));
+
     it('Sollte den korrekten, UTC-genullten Wert ausgeben', fakeAsync(() => {
       const utcNullifedDate = new Date(0);
       utcNullifedDate.setUTCFullYear(2000, 0, 1);

--- a/src/app/modules/lux-form/lux-datepicker/lux-datepicker.component.ts
+++ b/src/app/modules/lux-form/lux-datepicker/lux-datepicker.component.ts
@@ -13,9 +13,8 @@ import {
   ViewChild
 } from '@angular/core';
 import { ControlContainer } from '@angular/forms';
-import { DateAdapter, MAT_DATE_FORMATS } from '@angular/material/core';
+import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatDatepicker } from '@angular/material/datepicker';
-import { MAT_DATE_LOCALE } from '@angular/material/core';
 import { Subscription } from 'rxjs';
 import { LuxComponentsConfigService } from '../../lux-components-config/lux-components-config.service';
 import { LuxConsoleService } from '../../lux-util/lux-console.service';
@@ -176,8 +175,20 @@ export class LuxDatepickerComponent extends LuxFormInputBaseClass implements OnI
     setTimeout(() => {
       this.previousISO = isoValue;
 
-      // valueChange-Emitter anstoßen
-      this.notifyFormValueChanged(isoValue);
+      let minOk = true;
+      if (this.min && isoValue && this.dateAdapter.compareDate(new Date(isoValue), this.min) < 0) {
+        minOk = false;
+      }
+
+      let maxOk = true;
+      if (this.max && isoValue && this.dateAdapter.compareDate(new Date(isoValue), this.max) > 0) {
+        maxOk = false;
+      }
+
+      // Der valueChange-Emitter wird nur anstoßen, wenn das Datum innerhalb der Grenzen (min und max) liegt.
+      if (minOk && maxOk) {
+        this.notifyFormValueChanged(isoValue);
+      }
 
       // "silently" den FormControl auf den (potentiell) geänderten Wert aktualisieren
       this.formControl.setValue(isoValue, {


### PR DESCRIPTION
luxMaxDate greift bei 5- oder 6-stelligen Jahreszahlen nicht und luxValueChange empfängt event