### PR TITLE
Issue #88: lux-table: Tooltipps werden nur angezeigt, wenn der Header…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 11.0.1
+## Bug Fixes
+- **lux-table**: Tooltipps werden nur angezeigt, wenn der Header sortierbar ist. [Issue 88](https://github.com/IHK-GfI/lux-components/issues/88)
+
 # Version 11.0.0
 ## New
 - **allgemein**: Update auf Angular 11

--- a/src/app/demo/components-overview/table-example/table-example.component.html
+++ b/src/app/demo/components-overview/table-example/table-example.component.html
@@ -31,7 +31,7 @@
           [luxResponsiveBehaviour]="nameConfig.responsiveBehaviour?.value"
         >
           <lux-table-column-header>
-            <ng-template>Name</ng-template>
+            <ng-template><span [luxTooltip]="'Tooltipp Spalte \'Name\''">Name</span></ng-template>
           </lux-table-column-header>
           <lux-table-column-content>
             <ng-template let-element
@@ -52,7 +52,7 @@
           [luxResponsiveBehaviour]="symbolConfig.responsiveBehaviour?.value"
         >
           <lux-table-column-header>
-            <ng-template>Symbol</ng-template>
+            <ng-template><span [luxTooltip]="'Tooltipp Spalte \'Symbol\''">Symbol</span></ng-template>
           </lux-table-column-header>
           <lux-table-column-content>
             <ng-template let-element

--- a/src/app/modules/lux-common/lux-table/lux-table.component.html
+++ b/src/app/modules/lux-common/lux-table/lux-table.component.html
@@ -111,7 +111,7 @@
               <th
                 mat-header-cell
                 *matHeaderCellDef
-                mat-sort-header
+                mat-sort-header [disabled]="!tableColumn.luxSortable"
                 [ngClass]="
                   'lux-table-column-header-' +
                   i +

--- a/src/app/modules/lux-common/lux-table/lux-table.component.scss
+++ b/src/app/modules/lux-common/lux-table/lux-table.component.scss
@@ -89,10 +89,6 @@ lux-progress ::ng-deep mat-progress-bar {
         border-top: 1px solid rgba(0, 0, 0, 0.12);
       }
     }
-
-    .lux-table-header-blocked {
-      pointer-events: none;
-    }
   }
 
   &.lux-hide-borders {


### PR DESCRIPTION
… sortierbar ist