### PR TITLE
Issue #163 - lux-dialog - Dartstellungsfehler in Safari 

### DIFF
--- a/src/app/modules/lux-popups/lux-dialog/lux-dialog-structure/lux-dialog-structure.component.html
+++ b/src/app/modules/lux-popups/lux-dialog/lux-dialog-structure/lux-dialog-structure.component.html
@@ -1,4 +1,4 @@
-<div class="lux-dialog" fxLayout="column" cdkTrapFocus tabindex="0" #dialogBase>
+<div class="lux-dialog" fxLayout="column" #dialogBase>
   <div mat-dialog-title class="lux-dialog-title" fxFlex="0 0 auto">
     <ng-content select="lux-dialog-title"></ng-content>
   </div>


### PR DESCRIPTION
- blauer Rahmen entfernt und Tab-Index korrigiert
<img width="726" alt="Bildschirmfoto 2022-02-14 um 13 52 26" src="https://user-images.githubusercontent.com/49644099/153868272-63178194-0add-4821-ae8e-a00e067ba08a.png">

Bitte testen!
Lux-Dialog öffnen und Tab-Index prüfen. Gewünschter Zustand: Focus-Wechsel nur zwischen den beiden Buttons.
In Safari: option+Tab für den Tab-Index innerhalb des Dialog-Fensters nutzen
