### PR TITLE
Issue #185 - Neue Button-Variante  und weitere Themeanpassungen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 11.14.0
+## New
+- **lux-button**: Die Variante luxStroked wurde eingeführt. [Issue 185](https://github.com/IHK-GfI/lux-components/issues/185)
 # Version 11.13.0
 ## New
 - **lux-autocomplete**, **lux-chips**, **lux-lookup-autocomplete**: Mehrzeilige Mat-Option im Dropdown-Menü eingeführt. [Issue 177](https://github.com/IHK-GfI/lux-components/issues/177)

--- a/src/app/demo/components-overview/button-example/button-example.component.html
+++ b/src/app/demo/components-overview/button-example/button-example.component.html
@@ -12,7 +12,7 @@
       >
         <h3 class="lux-highlight-section-label">Default</h3>
         <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="grid 12px">
-          <div fxFlex="0 1 calc(33% - 12px)" fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="8px">
+          <div fxFlex="0 1 calc(25% - 12px)" fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="8px">
             <lux-button
               *ngFor="let color of colors; let i = index"
               style="height: 60px"
@@ -29,7 +29,24 @@
             >
             </lux-button>
           </div>
-          <div fxFlex="0 1 calc(33% - 12px)" fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="8px">
+          <div fxFlex="0 1 calc(25% - 12px)" fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="8px">
+            <lux-button
+              *ngFor="let color of colors; let i = index"
+              style="height: 60px"
+              [luxLabel]="label"
+              [luxColor]="color.value"
+              [luxIconName]="iconName"
+              [luxIconShowRight]="iconShowRight"
+              [luxStroked]="true"
+              [luxIconAlignWithLabel]="align"
+              [luxDisabled]="disabled"
+              luxTagId="demo-button-default{{ i }}"
+              (luxClicked)="log(showOutputEvents, 'Button clicked', $event)"
+              (luxAuxClicked)="log(showOutputEvents, 'Aux-Button clicked', $event)"
+            >
+            </lux-button>
+          </div>
+          <div fxFlex="0 1 calc(25% - 12px)" fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="8px">
             <lux-button
               *ngFor="let color of colors; let i = index"
               style="height: 60px"
@@ -38,6 +55,7 @@
               [luxIconName]="iconName"
               [luxIconShowRight]="iconShowRight"
               [luxRaised]="false"
+              [luxStroked]="false"
               [luxIconAlignWithLabel]="align"
               [luxDisabled]="disabled"
               luxTagId="demo-button-hover{{ i }}"
@@ -46,7 +64,7 @@
             >
             </lux-button>
           </div>
-          <div fxFlex="0 1 calc(33% - 12px)" fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="8px">
+          <div fxFlex="0 1 calc(25% - 12px)" fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="8px">
             <lux-button
               *ngFor="let color of colors; let i = index"
               style="height: 60px"

--- a/src/app/modules/lux-action/lux-action-model/lux-action-component-base.class.ts
+++ b/src/app/modules/lux-action/lux-action-model/lux-action-component-base.class.ts
@@ -15,6 +15,7 @@ export class LuxActionComponentBaseClass {
   @Input() luxTagId: string;
   @Input() luxDisabled: boolean;
   @Input() luxRounded: boolean;
+  @Input() luxStroked: boolean;
   @Input() luxIconAlignWithLabel = false;
 
   @Output() luxClicked: EventEmitter<any> = new EventEmitter();

--- a/src/app/modules/lux-action/lux-button/lux-button.component.html
+++ b/src/app/modules/lux-action/lux-button/lux-button.component.html
@@ -20,7 +20,28 @@
 </button>
 
 <button
-  *ngIf="!luxRaised && !luxRounded"
+  *ngIf="luxStroked && !luxRounded"
+  mat-stroked-button
+  [color]="luxColor"
+  (click)="clicked($event)"
+  (auxclick)="auxClicked($event)"
+  [disabled]="luxDisabled"
+  [type]="luxType"
+  class="lux-button lux-bold lux-align-center"
+  luxTagIdHandler
+  [luxTagId]="luxTagId"
+  [ngClass]="{ 'lux-align-baseline': luxIconAlignWithLabel && !!luxIconName, 'lux-icon-button': !!luxIconName }"
+  [attr.aria-label]="luxLabel ? luxLabel : ''"
+>
+  <ng-container *ngTemplateOutlet="luxIconName && !luxIconShowRight ? iconTemplate : noIconTemplate"></ng-container>
+  <span class="lux-button-label" [ngClass]="{ 'lux-ml-3': !!luxIconName && !luxIconShowRight, 'lux-mr-3': !!luxIconName && luxIconShowRight }" *ngIf="luxLabel">
+    {{ luxLabel }}
+  </span>
+  <ng-container *ngTemplateOutlet="luxIconName && luxIconShowRight ? iconTemplate : noIconTemplate"></ng-container>
+</button>
+
+<button
+  *ngIf="!luxRaised && !luxRounded && !luxStroked"
   mat-button
   [color]="luxColor"
   (click)="clicked($event)"

--- a/src/app/modules/lux-action/lux-button/lux-button.component.spec.ts
+++ b/src/app/modules/lux-action/lux-button/lux-button.component.spec.ts
@@ -36,6 +36,14 @@ describe('LuxButtonComponent', () => {
       Checker.checkLuxClicked(fixture);
     }));
 
+    it('Button (stroked) anklicken"', fakeAsync(() => {
+      fixture.componentInstance.stroked = true;
+      fixture.componentInstance.round = false;
+      fixture.detectChanges();
+
+      Checker.checkLuxClicked(fixture);
+    }));
+
     it('Button (round)" anklicken', fakeAsync(() => {
       fixture.componentInstance.raised = false;
       fixture.componentInstance.round = true;
@@ -71,6 +79,14 @@ describe('LuxButtonComponent', () => {
       Checker.checkLuxDisabled(fixture);
     }));
 
+    it('Button (stroked) anklicken"', fakeAsync(() => {
+      fixture.componentInstance.stroked = true;
+      fixture.componentInstance.round = false;
+      fixture.detectChanges();
+
+      Checker.checkLuxDisabled(fixture);
+    }));
+
     it('Button (round) anklicken', fakeAsync(() => {
       fixture.componentInstance.raised = false;
       fixture.componentInstance.round = true;
@@ -100,6 +116,14 @@ describe('LuxButtonComponent', () => {
 
     it('Button (raised)"', fakeAsync(() => {
       fixture.componentInstance.raised = true;
+      fixture.componentInstance.round = false;
+      fixture.detectChanges();
+
+      Checker.checkLuxLabel(fixture);
+    }));
+
+    it('Button (stroked) anklicken"', fakeAsync(() => {
+      fixture.componentInstance.stroked = true;
       fixture.componentInstance.round = false;
       fixture.detectChanges();
 
@@ -185,6 +209,7 @@ class Checker {
       (luxClicked)="onClick($event)"
       [luxRounded]="round"
       [luxRaised]="raised"
+      [luxStroked]="stroked"
     ></lux-button>
   `
 })
@@ -192,6 +217,7 @@ class LuxButtonComponent {
   disabled: boolean;
   round: boolean;
   raised;
+  stroked;
 
   onClick() {}
 }
@@ -204,11 +230,13 @@ class LuxButtonComponent {
       (luxClicked)="onClick($event)"
       [luxRounded]="round"
       [luxRaised]="raised"
+      [luxStroked]="stroked"
     ></lux-button>
   `
 })
 class LuxButtonLabelComponent {
   round: boolean;
   raised;
+  stroked;
   label: string;
 }


### PR DESCRIPTION
lux-Button wurde um die Variante luxStroked erweitert.
![image](https://user-images.githubusercontent.com/49644099/161539162-0a1533cc-2ff4-4d52-b019-79513d3be80d.png)
![image](https://user-images.githubusercontent.com/49644099/161539267-e0fe4c72-5f76-4afd-b73a-590ead22f201.png)

Weitere Anpassungen für Hover und Disabled-State wurden im Theme gemäß der Vorgaben vorgenommen

