### PR TITLE
Issue #191 - LuxErrorPage ist nicht responsive

### DIFF
--- a/src/app/modules/lux-error/lux-error-page/lux-error-page.component.html
+++ b/src/app/modules/lux-error/lux-error-page/lux-error-page.component.html
@@ -1,5 +1,5 @@
 <lux-card ngClass.gt-sm="lux-error-page-desktop" id="ErrorPage" fxFlexFill>
-  <lux-card-content fxFlex="noshrink" fxLayout="column" fxLayoutAlign="center center">
+  <lux-card-content fxLayout="column" fxLayoutAlign="center center">
     <lux-icon
       [luxIconName]="errorConfig.iconName"
       [luxIconSize]="errorConfig.iconSize"
@@ -9,7 +9,7 @@
       ngClass.sm="lux-error-icon-sm"
       ngClass.xs="lux-error-icon-xs"
     ></lux-icon>
-    <h2 class="lux-ml-3 lux-mr-3">{{ errorConfig.errorText }}</h2>
+    <h2 class="lux-ml-3 lux-mr-3" style="text-align: center;">{{ errorConfig.errorText }}</h2>
     <lux-button
       luxColor="primary"
       [luxLabel]="errorConfig.homeRedirectText"


### PR DESCRIPTION
- Anpassung in lux-error-page.component

Die Lux-Errorpage passt sich jetzt auch in der mobilen Ansicht der Bildschirmbreite an.
![image](https://user-images.githubusercontent.com/49644099/165902282-8e92789b-8f9d-41b8-ae7d-66cf3cf42ffc.png)
