### PR TITLE
Issue #192 - lux-Filter-Form Tastaturbelegung konfigurierbar machen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 11.14.0
+## New
+- **lux-filter-form**: Die neue Property luxDisableShortcut ermöglicht das Abschalten dieser Funktion für den Filter. [Issue 192](https://github.com/IHK-GfI/lux-components/issues/192)
+
 # Version 11.13.0
 ## New
 - **lux-autocomplete**, **lux-chips**, **lux-lookup-autocomplete**: Mehrzeilige Mat-Option im Dropdown-Menü eingeführt. [Issue 177](https://github.com/IHK-GfI/lux-components/issues/177)

--- a/src/app/demo/components-overview/filter-example/filter-example.component.html
+++ b/src/app/demo/components-overview/filter-example/filter-example.component.html
@@ -23,6 +23,7 @@
         [luxButtonDialogDelete]="buttonDialogDelete"
         [luxButtonDialogCancel]="buttonDialogCancel"
         [luxButtonDialogClose]="buttonDialogClose"
+        [luxDisableShortcut]="disableShortcut"
         class="lux-ml-1 lux-mr-1 lux-mb-3"
       >
         <lux-layout-form-row luxWrapAt="md">
@@ -154,6 +155,10 @@
       <lux-select luxLabel="luxButtonDialogLoad" [(luxSelected)]="buttonDialogLoad" [luxOptions]="buttonColorOptions"></lux-select>
       <lux-select luxLabel="luxButtonDialogDelete" [(luxSelected)]="buttonDialogDelete" [luxOptions]="buttonColorOptions"></lux-select>
       <lux-select luxLabel="luxButtonDialogClose" [(luxSelected)]="buttonDialogClose" [luxOptions]="buttonColorOptions"></lux-select>
+    </div>
+    <div class="lux-highlight-section filter-config-item" fxLayout="column">
+      <h3 class="lux-highlight-section-label">Tastaturkürzel</h3>
+      <lux-toggle luxLabel="luxDisableShortcut" [(luxChecked)]="disableShortcut" luxHint="Über dieses Property kann das Tastaturkürzel &quot;Shift + Enter&quot; zum Auslösen des Filters abgeschaltet werden."></lux-toggle>
     </div>
   </example-base-simple-options>
   <example-base-advanced-options>

--- a/src/app/demo/components-overview/filter-example/filter-example.component.ts
+++ b/src/app/demo/components-overview/filter-example/filter-example.component.ts
@@ -123,6 +123,8 @@ export class FilterExampleComponent implements OnInit, OnDestroy {
   buttonDialogCancel = 'default';
   buttonDialogClose = 'default';
 
+  disableShortcut = false;
+
   constructor(private mediaQuery: LuxMediaQueryObserverService) {}
 
   ngOnInit(): void {

--- a/src/app/modules/lux-filter/lux-filter-form/lux-filter-form.component.html
+++ b/src/app/modules/lux-filter/lux-filter-form/lux-filter-form.component.html
@@ -19,7 +19,7 @@
           luxIconName="fas fa-filter"
           [luxColor]="luxButtonFilterColor"
           [luxRaised]="luxButtonRaised"
-          luxButtonTooltip="(Shift + Enter)"
+          luxButtonTooltip="{{ luxDisableShortcut ? '' : '(Shift + Enter)' }}"
           (luxClicked)="onFilter()"
         ></lux-menu-item>
         <lux-menu-item

--- a/src/app/modules/lux-filter/lux-filter-form/lux-filter-form.component.ts
+++ b/src/app/modules/lux-filter/lux-filter-form/lux-filter-form.component.ts
@@ -59,6 +59,7 @@ export class LuxFilterFormComponent implements OnInit, AfterViewInit, OnDestroy 
   @Input() luxDefaultFilterMessage = $localize `:@@luxc.filter.defaultFilterMessage:Es wird nach den Standardeinstellungen gefiltert.`;
   @Input() luxShowChips = true;
   @Input() luxStoredFilters: LuxFilter[] = [];
+  @Input() luxDisableShortcut = false;
 
   @Input()
   get luxFilterExpanded() {
@@ -264,24 +265,26 @@ export class LuxFilterFormComponent implements OnInit, AfterViewInit, OnDestroy 
     // besteht natürlich auch beim Datepicker, Select und den
     // Lookup-Komponenten. Aus diesem Grund werden hier zuerst alle geöffneten
     // Popups/Panels geschlossen. Im Anschluss wird wie gewohnt gefiltert.
-    this.formElementes.forEach((formComponent) => {
-      if (formComponent.datepicker) {
-        formComponent.datepicker.matDatepicker.close();
-      } else if (formComponent.datetimepicker) {
-        formComponent.datetimepicker.dateTimeOverlayComponent.close();
-      } else if (formComponent.select) {
-        formComponent.select.matSelect.close();
-      } else if (formComponent.autoComplete) {
-        formComponent.autoComplete.matAutoComplete.closePanel();
-      } else if (formComponent.autoCompleteLookup) {
-        formComponent.autoCompleteLookup.matAutocompleteTrigger.closePanel();
-      } else if (formComponent.selectLookup) {
-        formComponent.selectLookup.matSelect.close();
-      }
-    });
+    if (!this.luxDisableShortcut) {    
+      this.formElementes.forEach((formComponent) => {
+        if (formComponent.datepicker) {
+          formComponent.datepicker.matDatepicker.close();
+        } else if (formComponent.datetimepicker) {
+          formComponent.datetimepicker.dateTimeOverlayComponent.close();
+        } else if (formComponent.select) {
+          formComponent.select.matSelect.close();
+        } else if (formComponent.autoComplete) {
+          formComponent.autoComplete.matAutoComplete.closePanel();
+        } else if (formComponent.autoCompleteLookup) {
+          formComponent.autoCompleteLookup.matAutocompleteTrigger.closePanel();
+        } else if (formComponent.selectLookup) {
+          formComponent.selectLookup.matSelect.close();
+        }
+      });
 
-    this.onFilter();
-    this.cdr.detectChanges();
+      this.onFilter();
+      this.cdr.detectChanges();
+    }
   }
 
   onFilter() {


### PR DESCRIPTION
Damit in allen Anwendungen, die die Lux-Components verwenden das Tastaturkürzel einheitlich bleibt, haben wir uns zur Lösung des Problems dazu entschieden, dass das Tasturkürzel für den Filter abschaltbar ist.
 
Folgende Dateien wurden geänderten
-lux-filter-form: Komponente mit neuer Property luxDisableShortcut versehen
-filter-demo: Demo für die neue Property überarbeitet