### PR TITLE
Issue 248:  das User-Menu in Lux-app-header-ac wird immer angezeigt. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **allgemein**: Update auf LUX-Components-Icons-And-Fonts [1.1.0](https://github.com/IHK-GfI/lux-components-icons-and-fonts/releases/tag/1.1.0).
 
+## Bug Fixes
+
+- **lux-app-header-ac**: Das User-Menu wird immer angezeigt. [Issue 248](https://github.com/IHK-GfI/lux-components/issues/248)
+
 # Version 14.0.0
 ## New
 - **allgemein**: Update auf Angular 14 [Issue 223](https://github.com/IHK-GfI/lux-components/issues/223)

--- a/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.html
+++ b/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.html
@@ -58,6 +58,7 @@
 
       <!-- User-Menu -->
       <lux-menu
+        *ngIf="userMenu"
         class="lux-user-menu"
         ngClass.lt-md="lux-user-menu-mobile"
         [luxDisplayExtended]="false"


### PR DESCRIPTION
…Gefixt: Wenn die Chidkomponente fehlt, wird das Menü/Trigger nicht mehr angezeigt.

Bitte Testen und Codereview durchführen.