### PR TITLE
Issue 239 Lux-Stepper-Large-styling-Issue

### DIFF
--- a/src/app/demo/components-overview/stepper-large-example/stepper-large-example.component.html
+++ b/src/app/demo/components-overview/stepper-large-example/stepper-large-example.component.html
@@ -62,7 +62,7 @@
       luxTitle="Füllschritt 2 - Duis autem vel eum iriure dolor in hendrerit"
       [luxDisabled]="true"
     ></lux-stepper-large-extern-step-example>
-    <lux-stepper-large-extern-step-example [luxCompleted]="completed" luxTitle="Füllschritt 3 - Ut wisi enim ad">
+    <lux-stepper-large-extern-step-example [luxCompleted]="completed" luxTitle="Füllschritt 3 - Ut wisi enim ad, iriure dolor in hendrerit">
     </lux-stepper-large-extern-step-example>
     <lux-stepper-large-extern-step-example [luxCompleted]="completed" luxTitle="Füllschritt 4 - Nam liber tempor">
     </lux-stepper-large-extern-step-example>

--- a/src/app/modules/lux-layout/lux-stepper-large/lux-stepper-large-subcomponents/lux-stepper-large-mobile-overlay/lux-stepper-large-mobile-overlay.component.html
+++ b/src/app/modules/lux-layout/lux-stepper-large/lux-stepper-large-subcomponents/lux-stepper-large-mobile-overlay/lux-stepper-large-mobile-overlay.component.html
@@ -29,12 +29,6 @@
           </div>
           <div class="lux-stepper-large-nav-item-label-container lux-stepper-large-mobile-nav-item-label-container">
             <ng-container *ngTemplateOutlet="step.luxTouched && !step.luxDisabled ? link : nolink; context: { step: step, i: i}"></ng-container>
-            <lux-icon
-              class="lux-stepper-large-nav-item-complete lux-stepper-large-mobile-nav-item-complete"
-              luxPadding="0 0 0 12px"
-              luxIconName="lux-interface-validation-check"
-              *ngIf="step.luxTouched && step.luxCompleted"
-            ></lux-icon>
           </div>
         </div>
       </ng-container>

--- a/src/app/modules/lux-layout/lux-stepper-large/lux-stepper-large.component.html
+++ b/src/app/modules/lux-layout/lux-stepper-large/lux-stepper-large.component.html
@@ -57,12 +57,6 @@
       </div>
       <div class="lux-stepper-large-nav-item-label-container">
         <ng-container *ngTemplateOutlet="step.luxTouched && !step.luxDisabled ? link : nolink; context: { step: step, i: i}"></ng-container>
-        <lux-icon
-          class="lux-stepper-large-nav-item-complete"
-          luxPadding="0 0 0 12px"
-          luxIconName="lux-interface-validation-check"
-          *ngIf="step.luxTouched && step.luxCompleted"
-        ></lux-icon>
       </div>
     </div>
   </ng-container>


### PR DESCRIPTION
Das Icon hinter dem Label im Nav-Item wird nun direkt hinter dem Label-Text angezeigt. Dafür wurde das Icon-Element aus dem Template entfernt. Stattdessen wird es nun über das Css angezeigt. Die Anpassungen wurden für die Desktop-Ansicht und die Mobile Version durchgeführt.
Vergleiche: https://github.com/IHK-GfI/lux-components-theme/tree/feature/Issue_239_Lux_Stepper_Large_Styling_Issue
