### PR TITLE
Issue #271: Auswahlbox bei lux-select-ac in Theme authentic ungünstig…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **lux-dialog**: Die Property "disableClose" ist wirkungslos. [Issue 264](https://github.com/IHK-GfI/lux-components/issues/264)
 - **lux-dialog**: Der Inhalt nimmt nicht die gesamte Breite und Höhe ein. [Issue 264](https://github.com/IHK-GfI/lux-components/issues/264)
 - **lux-lookup-combobox**: Das Array des Output-Events "luxDataLoadedAsArray" wird nachträglich verändert. [Issue 274](https://github.com/IHK-GfI/lux-components/issues/274)
+- **lux-select-ac**, **lux-lookup-combobox-ac**: Auswahlbox bei lux-select-ac im Theme authentic ungünstig positioniert. [Issue 271](https://github.com/IHK-GfI/lux-components/issues/271)
 
 # Version 14.1.0
 

--- a/src/app/demo/components-overview/select-authentic-example/select-authentic-example.component.ts
+++ b/src/app/demo/components-overview/select-authentic-example/select-authentic-example.component.ts
@@ -26,6 +26,7 @@ export class SelectAuthenticExampleComponent {
   useSimpleArray = false;
   showOutputEvents = false;
   options: { label: string; value: number }[] = [
+    { label: 'Argentinien, Bolivien, Chile, Costa Rica, Dominikanische Republik, Ecuador, El Salvador, Guatemala, Honduras, Kolumbien, Kuba, Mexiko', value: 0 },
     { label: 'Afghanistan', value: 1 },
     { label: 'Albanien', value: 2 },
     { label: 'Algerien', value: 3 },

--- a/src/app/demo/components-overview/select-example/select-example.component.ts
+++ b/src/app/demo/components-overview/select-example/select-example.component.ts
@@ -26,6 +26,7 @@ export class SelectExampleComponent {
   useSimpleArray = false;
   showOutputEvents = false;
   options: { label: string; value: number }[] = [
+    { label: 'Argentinien, Bolivien, Chile, Costa Rica, Dominikanische Republik, Ecuador, El Salvador, Guatemala, Honduras, Kolumbien, Kuba, Mexiko', value: 0 },
     { label: 'Afghanistan', value: 1 },
     { label: 'Albanien', value: 2 },
     { label: 'Algerien', value: 3 },

--- a/src/app/modules/lux-form/lux-select-ac/lux-select-ac.component.html
+++ b/src/app/modules/lux-form/lux-select-ac/lux-select-ac.component.html
@@ -15,8 +15,7 @@
     [placeholder]="luxPlaceholder"
     [multiple]="luxMultiple"
     [compareWith]="compareObjects"
-    [required]="luxRequired"
-    disableOptionCentering
+    [required]="luxRequired"  
     [disableRipple]="true"
     [formControl]="formControl"
     [attr.aria-invalid]="formControl.invalid"

--- a/src/app/modules/lux-lookup/lux-lookup-combobox-ac/lux-lookup-combobox-ac.component.html
+++ b/src/app/modules/lux-lookup/lux-lookup-combobox-ac/lux-lookup-combobox-ac.component.html
@@ -19,7 +19,6 @@
     [luxTagId]="luxTagId"
     [panelClass]="luxMultiple ? 'lux-select-panel-ac-multiple': 'lux-select-panel-ac'"
     [disableRipple]="true"
-    disableOptionCentering
     [errorStateMatcher]="stateMatcher"
     [compareWith]="compareByKey"
     (focusin)="luxFocusIn.emit($event)"


### PR DESCRIPTION
… positioniert

- disableOptionCentering wurde für lux-select-ac und lux-lookup-combobox-ac zurückgenommen
- Positionierung im Theme wurde angepasst
- das Panel verdeckt wieder das Input
- das Demo wurde mit einem langem Option-Text ergänzt
- ein Redesign ist für v15.0.0 geplant