### PR TITLE
Issue #281: Aria-Labels für Lux-App-Header-ac

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -171,6 +171,8 @@
     luxAppIconName="dashboard_customize"
     luxBrandLogoSrc="assets/svg/IHK_GfI.svg"
     luxAppLogoSrc="assets/favicons/favicon.svg"
+    luxAriaTitleIconLabel="Appicon / Zur Startseite"
+    luxAriaTitleImageLabel="Brandlogo / Zur Homepage"
     [luxLocaleSupported]="['de', 'en']"
     (luxClicked)="router.navigate(['/'])"
     (luxAppLogoClicked)="goToHome()"

--- a/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.html
+++ b/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.html
@@ -1,4 +1,9 @@
-<div fxLayout="column" class="lux-app-header-ac-container">
+<div
+  fxLayout="column"
+  class="lux-app-header-ac-container"
+  [luxAriaRole]="luxAriaRoleHeaderLabel ? 'banner' : undefined"
+  [luxAriaLabel]="luxAriaRoleHeaderLabel"
+>
   <!-- Top-Bar -->
   <div
     *ngIf="!luxHideTopBar"
@@ -12,10 +17,11 @@
     <div fxFlex.gt-sm="0 0 45" fxFlex.lt-md="30" fxLayoutAlign="start center" class="lux-brand-logo-container">
       <lux-image
         [luxImageSrc]="luxBrandLogoSrc"
-        [luxImageHeight]="mobileView ? '24px': '40px'"
+        [luxImageHeight]="mobileView ? '24px' : '40px'"
         class="lux-brand-logo"
         [ngClass]="{ 'lux-brand-logo-mobile': mobileView }"
         luxAlt="Lux-Brand-Logo"
+        [luxAriaLabel]="luxAriaTitleImageLabel"
         luxTagId="lux-brand-logo-button"
         (luxClicked)="onBrandLogoClicked($event)"
         *ngIf="luxBrandLogoSrc"
@@ -29,6 +35,7 @@
         luxImageHeight="40px"
         class="lux-app-logo"
         luxAlt="Lux-App-Logo"
+        [luxAriaLabel]="luxAriaTitleIconLabel"
         (luxClicked)="onAppLogoClicked($event)"
         *ngIf="luxAppLogoSrc"
       ></lux-image>
@@ -45,7 +52,7 @@
       [luxAriaLabel]="luxAriaUserMenuButtonLabel"
     >
       <div fxflex="0 0 auto" *ngIf="actionNav" class="lux-action-nav-ac-container">
-         <ng-container [ngTemplateOutlet]="actionNav.templateRef" *ngIf="actionNav"></ng-container>
+        <ng-container [ngTemplateOutlet]="actionNav.templateRef" *ngIf="actionNav"></ng-container>
       </div>
 
       <lux-lang-select-ac
@@ -71,11 +78,7 @@
         fxFlex="0 0 auto"
       >
         <!-- Anzeige des Usernames falls dieser vorhanden und eingeloggt ist -->
-        <lux-menu-item *ngIf="luxUserName"
-          [luxLabel]="luxUserName"
-          [luxDisabled]="true"
-          luxClass="lux-user-name-label"
-        ></lux-menu-item>
+        <lux-menu-item *ngIf="luxUserName" [luxLabel]="luxUserName" [luxDisabled]="true" luxClass="lux-user-name-label"></lux-menu-item>
 
         <ng-container *ngFor="let menuItem of userMenu?.menuItemComponents">
           <lux-menu-item
@@ -95,7 +98,7 @@
         <lux-menu-trigger>
           <lux-button
             [luxRounded]="true"
-            [luxIconName]="luxUserName ? 'lux-interface-user-check' : 'lux-interface-user-single' "
+            [luxIconName]="luxUserName ? 'lux-interface-user-check' : 'lux-interface-user-single'"
             luxColor="primary"
             class="user-menu-trigger-ac"
             ngClass.lt-md="user-menu-trigger-mobile"
@@ -132,7 +135,7 @@
       ></lux-image>
       <div class="lux-app-title" [ngClass]="{ 'lux-mobile': mobileView }">{{ mobileView ? luxAppTitleShort : luxAppTitle }}</div>
     </div>
-    <div fxFlex="fill"  class="lux-app-nav-menu">
+    <div fxFlex="fill" class="lux-app-nav-menu">
       <ng-content select="lux-app-header-ac-nav-menu" *ngIf="navMenu"></ng-content>
     </div>
   </div>

--- a/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.ts
+++ b/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.ts
@@ -1,4 +1,15 @@
-import { Component, ContentChild, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
+import {
+  Component,
+  ContentChild,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 import { Subscription } from 'rxjs';
 import { LuxComponentsConfigService } from '../../lux-components-config/lux-components-config.service';
 import { LuxAppService } from '../../lux-util/lux-app.service';
@@ -19,11 +30,14 @@ export class LuxAppHeaderAcComponent implements OnInit, OnChanges {
   @Input() luxAppTitleShort?: string;
   @Input() luxBrandLogoSrc?: string;
   @Input() luxAppLogoSrc?: string;
-  @Input() luxAriaUserMenuButtonLabel = $localize `:@@luxc.app-header.aria.usermenu.btn:Benutzermenü / Navigation`;
   @Input() luxLocaleSupported = ['de'];
-  @Input() luxLocaleBaseHref  = '';
+  @Input() luxLocaleBaseHref = '';
   @Input() luxHideTopBar = false;
   @Input() luxHideNavBar = false;
+  @Input() luxAriaRoleHeaderLabel = $localize`:@@luxc.app-header.aria.role_header.lbl:Kopfbereich / Menübereich`;
+  @Input() luxAriaUserMenuButtonLabel = $localize`:@@luxc.app-header.aria.usermenu.btn:Benutzermenü / Navigation`;
+  @Input() luxAriaTitleIconLabel = $localize`:@@luxc.app-header.aria.title_icon.lbl:Titelicon`;
+  @Input() luxAriaTitleImageLabel = $localize`:@@luxc.app-header.aria.title.image.lbl:Titelbild`;
 
   @Output() luxClicked: EventEmitter<Event> = new EventEmitter();
   @Output() luxAppLogoClicked: EventEmitter<Event> = new EventEmitter();
@@ -35,7 +49,6 @@ export class LuxAppHeaderAcComponent implements OnInit, OnChanges {
   @ContentChild(LuxAppHeaderAcUserMenuComponent) userMenu?: LuxAppHeaderAcUserMenuComponent;
   @ContentChild(LuxAppHeaderAcActionNavComponent) actionNav?: LuxAppHeaderAcActionNavComponent;
 
-  hasOnClickedListener?: boolean;
   userNameShort?: string;
 
   mobileView: boolean;
@@ -44,17 +57,17 @@ export class LuxAppHeaderAcComponent implements OnInit, OnChanges {
   menuOpened = false;
 
   private iconBasePath = '';
-  
+
   constructor(
     private logger: LuxConsoleService,
     private queryService: LuxMediaQueryObserverService,
-    private elementRef: ElementRef, 
+    private elementRef: ElementRef,
     private appService: LuxAppService,
     private configService: LuxComponentsConfigService
-    ) {
-    this.mobileView = this.queryService.activeMediaQuery === 'xs' || this.queryService.activeMediaQuery === 'sm'
-    this.subscription = this.queryService.getMediaQueryChangedAsObservable().subscribe(query => {
-      this.mobileView = query === 'xs' ||  query === 'sm';
+  ) {
+    this.mobileView = this.queryService.activeMediaQuery === 'xs' || this.queryService.activeMediaQuery === 'sm';
+    this.subscription = this.queryService.getMediaQueryChangedAsObservable().subscribe((query) => {
+      this.mobileView = query === 'xs' || query === 'sm';
     });
     this.appService.appHeaderEl = elementRef.nativeElement;
     this.iconBasePath = this.configService.currentConfig.iconBasePath ?? '';
@@ -64,14 +77,10 @@ export class LuxAppHeaderAcComponent implements OnInit, OnChanges {
   }
 
   ngOnInit(): void {
-    //für die lux-images für das Brandlogo und Applogo
-    if (this.luxClicked.observed) {
-      this.hasOnClickedListener = true;
-    }
-    if(!this.luxAppLogoSrc) {
+    if (!this.luxAppLogoSrc) {
       this.luxAppLogoSrc = this.iconBasePath + '/assets/logos/app_logo_platzhalter.svg';
     }
-    if(!this.luxBrandLogoSrc) {
+    if (!this.luxBrandLogoSrc) {
       this.luxBrandLogoSrc = this.iconBasePath + '/assets/logos/ihk_logo_platzhalter.svg';
     }
   }
@@ -91,10 +100,6 @@ export class LuxAppHeaderAcComponent implements OnInit, OnChanges {
     if (this.customTrigger) {
       this.customTrigger.nativeElement.children[0].focus();
     }
-  }
-
-  onClicked(event: any) {
-    this.luxClicked.emit(event);
   }
 
   onAppLogoClicked(event: any) {


### PR DESCRIPTION
- die Arialabels wurden mit den bisherigen Bezeichungen von lux-app-header für den neuen Header hinzugefügt 
- luxAriaAppMenuButtonLabel und luxAriaTitleLinkLabel werden nicht mehr genutzt
- ungenutzte Properties wurden entfernt