### PR TITLE
Issue #336: fix for missing file icons in lux-file-upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 14.7.0
+
+## Bug Fixes
+
+- **lux-file-upload**: Beim Zurückgehen im lux-stepper konnte es dazu kommen, dass die File-Icons nicht mehr angezeigt wurden. [Issue 336](https://github.com/IHK-GfI/lux-components/issues/336)
+
 # Version 14.6.0
 
 ## New

--- a/src/app/modules/lux-form/lux-file/lux-file-upload/lux-file-upload.component.ts
+++ b/src/app/modules/lux-form/lux-file/lux-file-upload/lux-file-upload.component.ts
@@ -153,6 +153,7 @@ export class LuxFileUploadComponent extends LuxFormFileBase<ILuxFileObject[] | n
   }
 
   ngAfterViewInit() {
+    this.setFileIcons(this.formControl.value);
     this.subscriptions.push(
       this.fileEntries.changes.subscribe(() => {
         this.setFileIcons(this.formControl.value);


### PR DESCRIPTION
Wenn ein lux-file-upload component in einem Stepper verwendet wird, man Dateien dem lux-file-upload component hinzufügt und dann zum nächsten Step und wieder zurück wechselt sind die File-Icons verschwunden. Dieser Commit behebt das Problem.