### PR TITLE
Issue #338: lux-master-detail-ac Mobile-Ansicht

### DIFF
--- a/src/app/demo/components-overview/master-detail-authentic-example/master-detail-authentic-example.component.html
+++ b/src/app/demo/components-overview/master-detail-authentic-example/master-detail-authentic-example.component.html
@@ -17,13 +17,8 @@
   (luxSelectedDetailChange)="loadDetail($event)"
   fxFill
 >
-<lux-master-header-content-ac>
-    <lux-filter-form
-      fxFlex="1 1 auto"
-      [luxShowAsCard]="true"
-      [luxShowChips]="false"
-      [luxButtonFlat]="false"
-    >
+  <lux-master-header-content-ac>
+    <lux-filter-form fxFlex="1 1 auto" [luxShowAsCard]="true" [luxShowChips]="false" [luxButtonFlat]="false">
       <lux-select-ac
         luxLabel="Fälligkeit"
         [luxOptions]="options"
@@ -32,6 +27,12 @@
         (luxSelectedChange)="changeFilter($event)"
       >
       </lux-select-ac>
+      <lux-filter-form-extended>
+        <p>
+          Lorem ipsum, dolor sit amet consectetur adipisicing elit. A suscipit cumque explicabo debitis, sint culpa quia quis odio excepturi
+          asperiores.
+        </p>
+      </lux-filter-form-extended>
     </lux-filter-form>
   </lux-master-header-content-ac>
 
@@ -61,7 +62,11 @@
           <ng-template>
             <detail-example [masterDetailConfig]="configuration" [selectedDetail]="detail"></detail-example>
             <div class="example-tab-content">
-              <lux-toggle [(luxChecked)]="showCustomDetailHeader" luxLabel="Custom Detail-Header anzeigen" [luxNoLabels]="true"></lux-toggle>
+              <lux-toggle
+                [(luxChecked)]="showCustomDetailHeader"
+                luxLabel="Custom Detail-Header anzeigen"
+                [luxNoLabels]="true"
+              ></lux-toggle>
             </div>
           </ng-template>
         </lux-tab>
@@ -71,8 +76,7 @@
           </ng-template>
         </lux-tab>
         <lux-tab luxTitle="Deaktiviert" luxIconName="lux-interface-block" [luxDisabled]="true" class="example-tab-content">
-          <ng-template>
-          </ng-template>
+          <ng-template> </ng-template>
         </lux-tab>
       </lux-tabs>
     </ng-template>
@@ -81,20 +85,8 @@
   <lux-master-footer-ac>
     <div fxLayout="column">
       <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="end center">
-        <lux-button
-          luxLabel="#1"
-          [luxFlat]="true"
-          luxColor="primary"
-          (luxClicked)="selectedDetail = masterEntries[0]"
-        >
-        </lux-button>
-        <lux-button
-          luxLabel="#5"
-          [luxFlat]="true"
-          luxColor="primary"
-          (luxClicked)="selectedDetail = masterEntries[4]"
-        >
-        </lux-button>
+        <lux-button luxLabel="#1" [luxFlat]="true" luxColor="primary" (luxClicked)="selectedDetail = masterEntries[0]"> </lux-button>
+        <lux-button luxLabel="#5" [luxFlat]="true" luxColor="primary" (luxClicked)="selectedDetail = masterEntries[4]"> </lux-button>
         <lux-menu luxMenuIconName="lux-interface-setting-menu-1" luxTagId="master_footer_menu">
           <lux-menu-item
             luxLabel="Liste umkehren"

--- a/src/app/modules/lux-layout/lux-card/lux-card.component.html
+++ b/src/app/modules/lux-layout/lux-card/lux-card.component.html
@@ -8,7 +8,7 @@
   [luxTagId]="luxTagId"
   [class]="'lux-card'"
   [ngClass]="{ 'lux-cursor': !showButtons && hasCardAction && !luxDisabled }"
-  [ngClass.gt-sm]="{ 'lux-cursor': !showButtons && hasCardAction && !luxDisabled  }"
+  [ngClass.gt-sm]="{ 'lux-cursor': !showButtons && hasCardAction && !luxDisabled }"
 >
   <div fxFlex="flex" fxLayout="column" class="lux-overflow-y-hidden lux-card-content-container">
     <mat-card-title
@@ -122,12 +122,7 @@
         ></lux-button>
       </div>
       <!-- Der expanded Card-Content ist nur sichtbar, wenn der Ausklapp-Button geklickt wurde. -->
-      <div
-        class="lux-card-content-expanded lux-mt-4"
-        *ngIf="luxExpanded && contentExpandedComponent"
-        [@expansionAnim]="{ value: getAnimState(), params: { duration: getAnimDuration() } }"
-        (@expansionAnim.done)="expansionDone()"
-      >
+      <div class="lux-card-content-expanded lux-mt-4" *ngIf="luxExpanded && contentExpandedComponent">
         <ng-content select="lux-card-content-expanded"></ng-content>
       </div>
     </mat-card-content>

--- a/src/app/modules/lux-layout/lux-master-detail-ac/lux-master-detail-ac.component.html
+++ b/src/app/modules/lux-layout/lux-master-detail-ac/lux-master-detail-ac.component.html
@@ -26,12 +26,10 @@
     <!-- Header Element über der Master-Liste -->
     <lux-master-header-ac
       (luxOpened)="toggleList($event)"
-      [luxToggleHidden]="
-        (isMobile && !this.luxSelectedDetail && !luxOpen) || isMobile
-      "
+      [luxToggleHidden]="(isMobile && !this.luxSelectedDetail && !luxOpen) || isMobile"
       [ngClass]="{
         'lux-not-open': !luxOpen,
-        'lux-hidden': (!luxOpen && isMobile),
+        'lux-hidden': !luxOpen && isMobile,
         'lux-empty-master-header': !showMasterHeader && !isMobile && luxOpen
       }"
     >
@@ -61,14 +59,10 @@
           luxSubTitle="{{ masterElement | luxPropertyFromObject: masterSimple?.luxSubTitleProp ?? '' }}"
         >
           <lux-list-item-icon>
-            <ng-container
-              *ngTemplateOutlet="masterSimple?.iconTempRef ?? null; context: { $implicit: masterElement }"
-            ></ng-container>
+            <ng-container *ngTemplateOutlet="masterSimple?.iconTempRef ?? null; context: { $implicit: masterElement }"></ng-container>
           </lux-list-item-icon>
           <lux-list-item-content>
-            <ng-container
-              *ngTemplateOutlet="masterSimple?.contentTempRef ?? null; context: { $implicit: masterElement }"
-            ></ng-container>
+            <ng-container *ngTemplateOutlet="masterSimple?.contentTempRef ?? null; context: { $implicit: masterElement }"></ng-container>
           </lux-list-item-content>
         </lux-list-item>
 
@@ -118,40 +112,36 @@
       <span class="back-to-master-label" i18n="@@luxc.master-detail.back-to-master-label">Zurück zur Liste</span>
     </div>
     <!-- Detail-Header -->
-    <div class="detail-header-container"
-      fxLayout="row"
-      fxLayoutAlign="start center"
-    >
-    <lux-card
-      *ngIf="!detailHeader && luxDefaultDetailHeader"
-      luxTitle ="{{ luxMasterList[selectedPosition] | luxPropertyFromObject: masterSimple?.luxTitleProp ?? '' }}"
-      luxSubTitle="{{ luxMasterList[selectedPosition] | luxPropertyFromObject: masterSimple?.luxSubTitleProp ?? '' }}"
-      [luxTitleLineBreak]="luxTitleLineBreak"
-      fxFlex="1 1 100"
-      class="lux-detail-header-ac lux-mb-4"
-      luxTagId="defaultDetailHeader"
-    >
-      <lux-card-content *ngIf="luxMasterList[selectedPosition]">
-        <ng-container
-          *ngTemplateOutlet="masterSimple?.contentTempRef ?? null; context: { $implicit: luxMasterList[selectedPosition] }"
-        ></ng-container>
-      </lux-card-content>
-    </lux-card>
-    <ng-content select="lux-detail-header-ac" *ngIf="detailHeader"></ng-content>
+    <div class="detail-header-container" fxLayout="row" fxLayoutAlign="start center">
+      <lux-card
+        *ngIf="!detailHeader && luxDefaultDetailHeader && isDetailInvisible()"
+        luxTitle="{{ luxMasterList[selectedPosition] | luxPropertyFromObject: masterSimple?.luxTitleProp ?? '' }}"
+        luxSubTitle="{{ luxMasterList[selectedPosition] | luxPropertyFromObject: masterSimple?.luxSubTitleProp ?? '' }}"
+        [luxTitleLineBreak]="luxTitleLineBreak"
+        fxFlex="1 1 100"
+        class="lux-detail-header-ac lux-mb-4"
+        luxTagId="defaultDetailHeader"
+      >
+        <lux-card-content *ngIf="luxMasterList[selectedPosition]">
+          <ng-container
+            *ngTemplateOutlet="masterSimple?.contentTempRef ?? null; context: { $implicit: luxMasterList[selectedPosition] }"
+          ></ng-container>
+        </lux-card-content>
+      </lux-card>
+      <ng-content select="lux-detail-header-ac" *ngIf="detailHeader"></ng-content>
     </div>
     <div class="lux-detail-view-container">
-    <ng-template #detailViewContainerRef></ng-template>
-  </div>
+      <ng-template #detailViewContainerRef></ng-template>
+    </div>
     <!-- Das Empty-Icon und Empty-Label, wenn kein Detail gegeben ist -->
     <div
       class="lux-detail-empty"
-      [ngClass]="{ 'lux-display-none': isDetailInvisible() || selectedPosition > -1 }"
+      [ngClass]="{ 'lux-display-none': isDetailInvisible() || selectedPosition > -1, 'lux-mobile': isMobile }"
       fxLayout="column"
       fxLayoutAlign="center center"
       #detailEmpty
     >
-      <lux-icon class="lux-detail-empty-icon" [luxIconName]="luxEmptyIconDetail" [luxIconSize]="luxEmptyIconDetailSize">
-      </lux-icon>
+      <lux-icon class="lux-detail-empty-icon" [luxIconName]="luxEmptyIconDetail" [luxIconSize]="luxEmptyIconDetailSize"> </lux-icon>
       <span class="lux-detail-empty-icon-text">
         <strong>{{ luxEmptyLabelDetail }}</strong>
       </span>

--- a/src/app/modules/lux-layout/lux-master-detail-ac/lux-master-detail-ac.component.ts
+++ b/src/app/modules/lux-layout/lux-master-detail-ac/lux-master-detail-ac.component.ts
@@ -81,6 +81,7 @@ export class LuxMasterDetailAcComponent<T = any> implements OnInit, AfterContent
 
   isMobile: boolean;
   isMedium: boolean;
+
   detailContext = { $implicit: {} };
   flexMaster?: string;
   flexDetail?: string;
@@ -110,7 +111,7 @@ export class LuxMasterDetailAcComponent<T = any> implements OnInit, AfterContent
   }
 
   @Input()
-  set luxOpen(open){
+  set luxOpen(open) {
     this._luxOpen = open;
     this.updateOpen();
   }
@@ -122,7 +123,9 @@ export class LuxMasterDetailAcComponent<T = any> implements OnInit, AfterContent
 
   @Input()
   set luxSelectedDetail(value) {
-    this.updateDetail$.next(value);
+    if (value !== this._luxSelectedDetail) {
+      this.updateDetail$.next(value);
+    }
   }
 
   /* Master List Get/Set */
@@ -149,11 +152,11 @@ export class LuxMasterDetailAcComponent<T = any> implements OnInit, AfterContent
     this.isMedium = this.mediaObserver.isMD();
     this.subscriptions.push(
       this.mediaObserver.getMediaQueryChangedAsObservable().subscribe(() => {
-          this.isMobile = this.mediaObserver.isXS() || this.mediaObserver.isSM();
-          this.isMedium = this.mediaObserver.isMD();
-          if (this.isMobile || this.isMedium) {
-            this.updateOpen();
-          }
+        this.isMobile = this.mediaObserver.isXS() || this.mediaObserver.isSM();
+        this.isMedium = this.mediaObserver.isMD();
+        if (this.isMobile || this.isMedium) {
+          this.updateOpen();
+        }
       })
     );
   }
@@ -290,7 +293,7 @@ export class LuxMasterDetailAcComponent<T = any> implements OnInit, AfterContent
       if (this.isMobile) {
         this.flexMaster = '100';
         this.flexDetail = '0';
-      } else if (this.isMedium){
+      } else if (this.isMedium) {
         this.flexMaster = 'calc(50% - 30px)'; /** 30px = Gap zwischen Master und Detail */
         this.flexDetail = '50';
       } else {
@@ -333,20 +336,6 @@ export class LuxMasterDetailAcComponent<T = any> implements OnInit, AfterContent
   }
 
   /**
-   * Kümmert sich um das Zuklappen der Master-Liste, wenn zwischen Mobil- und Desktopansicht gewechselt wird.
-   */
-  // private handleViewCollapse() {
-  //   this.subscriptions.push(this.mobileHelperService.masterCollapsedObservable.subscribe((open: boolean) => {
-  //     // Falls nichts selektiert ist, sollte die Darstellung beim Wechsel in kleine Media Queries die Masterliste zeigen
-  //     if (this.isMobile && !this.luxSelectedDetail && !open) {
-  //       open = true;
-  //     }
-  //     this.luxOpen = open;
-  //     this.updateOpen();
-  //   }));
-  // }
-
-  /**
    * Kümmert sich um Änderungen an dem selektierten Detail.
    * Dabei werden mehrere Zuweisungen an das Detail über throttleTime gebündelt und nur das Aktuellste genommen.
    * Anschließend wird die Komponente angewiesen das neue Detail-Objekt zu rendern.
@@ -360,7 +349,6 @@ export class LuxMasterDetailAcComponent<T = any> implements OnInit, AfterContent
         } else {
           if (!this.compareObjects(this.luxSelectedDetail, detail)) {
             this.detailViewContainerRef.clear();
-
             if (detail) {
               this.detailContext = { $implicit: detail };
 
@@ -377,7 +365,6 @@ export class LuxMasterDetailAcComponent<T = any> implements OnInit, AfterContent
               );
               // Die Detailansicht nach dem Wechsel wieder nach oben scrollen lassen
               this.detailViewContainerRef.element.nativeElement.parentNode.scrollTop = 0;
-
               this.cdr.detectChanges();
             }
           }


### PR DESCRIPTION
- Initiales Laden ohne Selektiertes Element startet jetzt mit Master-Liste
- "Zurück zum Master"-Button bei leerem Detail ist wieder klickbar
- Card-Animation für den Filter entfernt