### PR TITLE
Patch 1

### DIFF
--- a/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.html
+++ b/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.html
@@ -25,8 +25,8 @@
         (luxClicked)="onBrandLogoClicked($event)"
         *ngIf="luxBrandLogoSrc; else tenantLogoOrEmptyBrandLogo"
       ></lux-image>
-      <ng-template #tenantLogoOrEmptyBrandLogo *ngIf="tenantLogo; else emptyBrandLogo">
-        <ng-content select="lux-tenant-logo"></ng-content>
+      <ng-template #tenantLogoOrEmptyBrandLogo>
+        <ng-content select="lux-tenant-logo" *ngIf="tenantLogo; else emptyBrandLogo"></ng-content>
       </ng-template>
       <ng-template #emptyBrandLogo>
         <div class="lux-brand-logo-empty"></div>

--- a/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.html
+++ b/src/app/modules/lux-layout/lux-app-header-ac/lux-app-header-ac.component.html
@@ -11,11 +11,9 @@
       [ngClass]="{ 'lux-mobile': mobileView, 'lux-centered': luxCenteredView }"
       [ngStyle]="{ 'max-width': luxCenteredView ? luxCenteredWidth : '100%' }"
     >
-      <!-- Zeige lux-tenant-logo falls vorhanden UND Attribut luxBrandLogoSrc nicht gesetzt ist, also das Attribut hat hier vorrang -->
-
-      <ng-content select="lux-tenant-logo" *ngIf="!luxBrandLogoSrc"></ng-content>
 
       <!-- Brand-Logo -->
+      <!-- Zeige lux-tenant-logo falls vorhanden UND Attribut luxBrandLogoSrc nicht gesetzt ist, also das Attribut hat hier vorrang -->
       <lux-image
         [luxImageSrc]="luxBrandLogoSrc"
         [luxImageHeight]="mobileView ? '24px' : '40px'"
@@ -25,8 +23,11 @@
         [luxAriaLabel]="luxAriaTitleImageLabel"
         luxTagId="lux-brand-logo-button"
         (luxClicked)="onBrandLogoClicked($event)"
-        *ngIf="luxBrandLogoSrc; else emptyBrandLogo"
+        *ngIf="luxBrandLogoSrc; else tenantLogoOrEmptyBrandLogo"
       ></lux-image>
+      <ng-template #tenantLogoOrEmptyBrandLogo *ngIf="tenantLogo; else emptyBrandLogo">
+        <ng-content select="lux-tenant-logo"></ng-content>
+      </ng-template>
       <ng-template #emptyBrandLogo>
         <div class="lux-brand-logo-empty"></div>
       </ng-template>


### PR DESCRIPTION
**PROBLEM**:  When a lux-tenant-logo is provided to the lux-app-header-ac instead of the luxBrandLogoSrc, the layout will not fit. The reason the fixed amount of columns of the lux-app-header-top-bar's grid layout, which is two or three, depending on the screen size.
Desktop:
![image](https://github.com/user-attachments/assets/adaca456-9cfa-413a-a157-da4917c398ea)
Mobile:
![image](https://github.com/user-attachments/assets/3bd7061d-b52c-486b-82bd-aeabc99e506f)

**SOLUTION**: Move the tenant logo to the position of the empty brand logo. This will ensure that the column grid template remains valid even if a tenant logo is provided.